### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# This file is used to ignore revisions when using `git blame`
+# https://git-scm.com/docs/git-blame#Documentation/git-blame.txt-blameignoreRevsFile
+#
+# To use this file:
+# 1. Add the full commit SHA of a revision to ignore on a new line
+# 2. Configure `git` to ignore blame using this file:
+#    `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+
+# chore: add ESLint configuration and fix linter issues (#787)
+4f6df1c74cf8d2ff21ae21465c1c7025ca48f1c5


### PR DESCRIPTION
- Add a file to ignore specific revisions when using `git blame`
- Provide instructions for configuring git to use this file