### PR TITLE
ci: set package-manager-cache to false in setup-node action

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -15,6 +15,7 @@ runs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: .node-version
+        package-manager-cache: false
 
     - id: cache-config
       name: Configure cache


### PR DESCRIPTION
- Update the setup-node action configuration to explicitly set package-manager-cache to false.