### PR TITLE
chore: add NODE_ENV to build task environment variables

### DIFF
--- a/.ai/plan/infrastructure-build-pipeline-1.md
+++ b/.ai/plan/infrastructure-build-pipeline-1.md
@@ -58,7 +58,7 @@ This implementation plan focuses on optimizing the Sparkle monorepo build pipeli
 | TASK-009 | Create package-specific build tasks (e.g., build:ui, build:theme) to enable granular dependency management | ✅ | 2025-09-05 |
 | TASK-010 | Optimize cache strategies by adding specific inputs/outputs for each package type (UI components, theme tokens, utilities) | ✅ | 2025-09-05 |
 | TASK-011 | Implement proper dependency chains: types -> utils -> theme -> ui -> storybook | ✅ | 2025-01-28 |
-| TASK-012 | Add environment variables to relevant tasks (NODE_ENV, STORYBOOK_ENV) for proper cache invalidation | | |
+| TASK-012 | Add environment variables to relevant tasks (NODE_ENV, STORYBOOK_ENV) for proper cache invalidation | ✅ | 2025-01-28 |
 | TASK-013 | Configure persistent tasks (dev, build:watch) with proper cache: false settings | | |
 | TASK-014 | Add turbo.json validation to ensure task definitions remain consistent | | |
 

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
         "tsconfig.json",
         "next.config.{js,ts,mjs,cjs}",
         ".storybook/**/*"
-      ]
+      ],
+      "env": ["NODE_ENV"]
     },
     "build:types": {
       "dependsOn": [],
@@ -51,6 +52,7 @@
       "dependsOn": ["@sparkle/theme#build:theme"],
       "outputs": ["dist/**"],
       "inputs": ["src/**/*.ts", "package.json", "tsconfig.json", "tsdown.config.ts"],
+      "env": ["NODE_ENV"],
       "cache": true
     },
     "build:ui": {
@@ -128,6 +130,7 @@
         "vitest.config.{ts,js}",
         "vite.config.ts"
       ],
+      "env": ["NODE_ENV"],
       "cache": true
     },
     "typecheck": {


### PR DESCRIPTION
- Add "env": ["NODE_ENV"] to the build task configuration.
- Include "env": ["NODE_ENV"] in the build:config and build:ui tasks.
- Ensure consistent environment variable usage across build tasks.

Relates to TASK-012 on #839.