### PR TITLE
build: standardize package.json exports

### DIFF
--- a/.ai/plan/infrastructure-build-pipeline-1.md
+++ b/.ai/plan/infrastructure-build-pipeline-1.md
@@ -72,7 +72,7 @@ This implementation plan focuses on optimizing the Sparkle monorepo build pipeli
 | TASK-016 | Standardize tsdown.config.ts configurations across all packages with consistent external dependencies | ✅ | 2025-09-05 |
 | TASK-017 | Optimize packages/ui build process to use either pure tsdown or optimized Vite+tsdown hybrid | ✅ | 2025-09-05 |
 | TASK-018 | Ensure all packages generate proper TypeScript declaration files with consistent declarationMap settings | ✅ | 2025-09-06 |
-| TASK-019 | Verify package.json exports field accuracy across all packages for both types and runtime imports | | |
+| TASK-019 | Verify package.json exports field accuracy across all packages for both types and runtime imports | ✅ | 2025-09-06 |
 | TASK-020 | Add build validation scripts to ensure output consistency and package integrity | | |
 | TASK-021 | Configure source maps properly for debugging across all packages | | |
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,16 +13,14 @@
       "types": "./dist/tailwind.d.ts",
       "import": "./dist/tailwind.js",
       "default": "./dist/tailwind.js"
-    },
-    "./eslint": {
-      "types": "./dist/eslint.d.ts",
-      "import": "./dist/eslint.js",
-      "default": "./dist/eslint.js"
     }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "clean": "rm -rf dist",

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts'],
+  entry: ['./src/index.ts', './src/tailwind.ts'],
   outDir: 'dist',
   format: ['esm'],
   dts: {

--- a/packages/error-testing/package.json
+++ b/packages/error-testing/package.json
@@ -2,8 +2,19 @@
   "name": "@sparkle/error-testing",
   "version": "0.1.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "clean": "rimraf dist",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -44,12 +44,14 @@
       "import": "./dist/react-native/index.js",
       "require": "./dist/react-native/index.cjs",
       "default": "./dist/react-native/index.js"
-    },
-    "./styles.css": "./dist/styles.css"
+    }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "build:analyze": "npm run build && npx size-limit",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,6 +13,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "clean": "rm -rf dist",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "clean": "rm -rf dist",

--- a/packages/utils/tsdown.config.ts
+++ b/packages/utils/tsdown.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts'],
+  entry: ['./src/index.ts', './src/react.ts', './src/string.ts'],
   outDir: 'dist',
   format: ['esm'],
   dts: {


### PR DESCRIPTION
- Verify package.json exports field accuracy across all packages
- Add missing exports fields in package.json for multiple packages
- Update tsdown.config.ts to include additional entry points for builds

Relates to TASK-019 on #840.