### PR TITLE
chore: update documentation and TypeScript configurations

### DIFF
--- a/.ai/plan/feature-astro-starlight-docs-1.md
+++ b/.ai/plan/feature-astro-starlight-docs-1.md
@@ -62,9 +62,9 @@ This implementation plan outlines the creation of a comprehensive documentation 
 | TASK-003 | Configure `docs/package.json` with proper workspace dependencies and scripts | ✅ | 2025-09-07 |
 | TASK-004 | Update `pnpm-workspace.yaml` to include new docs package structure | ✅ | 2025-09-07 |
 | TASK-005 | Configure Astro Starlight in `docs/astro.config.mjs` with Sparkle branding and navigation | | |
-| TASK-006 | Set up TypeScript configuration in `docs/tsconfig.json` extending root config | | |
+| TASK-006 | Set up TypeScript configuration in `docs/tsconfig.json` extending root config | ✅ | 2025-09-07 |
 | TASK-007 | Create initial Starlight configuration with sidebar navigation mirroring package structure | | |
-| TASK-008 | Update Turborepo `turbo.json` with docs build, dev, and deployment tasks | | |
+| TASK-008 | Update Turborepo `turbo.json` with docs build, dev, and deployment tasks | ✅ | 2025-09-07 |
 
 ### Implementation Phase 2: Documentation Infrastructure
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,36 @@
 {
-  "extends": "astro/tsconfigs/strict",
-  "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "extends": ["astro/tsconfigs/strict", "../tsconfig.json"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "types": ["astro/client", "node"],
+    "incremental": true,
+    "composite": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/content/*": ["./src/content/*"],
+      "@/styles/*": ["./src/styles/*"]
+    }
+  },
+  "include": [".astro/types.d.ts", "src/**/*", "astro.config.mjs"],
+  "exclude": ["node_modules", "dist", ".astro"],
+  "references": [
+    {
+      "path": "../packages/types"
+    },
+    {
+      "path": "../packages/utils"
+    },
+    {
+      "path": "../packages/theme"
+    },
+    {
+      "path": "../packages/ui"
+    }
+  ]
 }

--- a/scripts/validate-turbo.ts
+++ b/scripts/validate-turbo.ts
@@ -132,6 +132,7 @@ class TurboValidator {
           'packages/ui',
           'packages/utils',
           'apps/fro-jive',
+          'docs',
         ]
 
         for (const pkgPath of knownPackages) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     {"path": "packages/config"},
     {"path": "packages/error-testing"},
     {"path": "packages/ui"},
-    {"path": "packages/storybook"}
+    {"path": "packages/storybook"},
+    {"path": "docs"}
   ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -84,6 +84,18 @@
       "env": ["NODE_ENV", "STORYBOOK_ENV"],
       "cache": true
     },
+    "build:docs": {
+      "dependsOn": [
+        "@sparkle/ui#build:ui",
+        "@sparkle/theme#build:theme",
+        "@sparkle/types#build:types",
+        "@sparkle/utils#build:utils"
+      ],
+      "outputs": ["dist/**"],
+      "inputs": ["src/**/*", "astro.config.mjs", "package.json", "tsconfig.json"],
+      "env": ["NODE_ENV"],
+      "cache": true
+    },
     "build:types:watch": {
       "dependsOn": ["^build"],
       "persistent": true,
@@ -108,7 +120,8 @@
         "tsconfig.json",
         ".env.*local",
         "vite.config.ts",
-        "next.config.{js,ts,mjs,cjs}"
+        "next.config.{js,ts,mjs,cjs}",
+        "astro.config.mjs"
       ],
       "env": ["NODE_ENV", "STORYBOOK_ENV"]
     },
@@ -189,6 +202,18 @@
         "vite.config.ts"
       ],
       "env": ["NODE_ENV"]
+    },
+    "preview:docs": {
+      "dependsOn": ["@sparkle/docs#build:docs"],
+      "cache": false,
+      "inputs": ["dist/**"],
+      "env": ["NODE_ENV"]
+    },
+    "deploy:docs": {
+      "dependsOn": ["@sparkle/docs#build:docs"],
+      "cache": false,
+      "inputs": ["dist/**", ".github/workflows/**"],
+      "env": ["NODE_ENV", "GITHUB_TOKEN"]
     },
     "clean": {
       "cache": false,


### PR DESCRIPTION
- Set up TypeScript configuration in `docs/tsconfig.json` with extended options.
- Mark tasks as completed in the Astro Starlight documentation plan.
- Add `docs` directory to known packages in TurboValidator.
- Update Turbo configuration to include build and deploy tasks for documentation.

Relates to TASK-006 and TASK-008 on #871.