### PR TITLE
feat: add Markdown documentation generation script and initial component docs

### DIFF
--- a/.ai/plan/feature-astro-starlight-docs-1.md
+++ b/.ai/plan/feature-astro-starlight-docs-1.md
@@ -73,8 +73,8 @@ This implementation plan outlines the creation of a comprehensive documentation 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
 | TASK-009 | Install and configure TypeDoc for API reference generation from TypeScript interfaces | ✅ | 2025-09-07 |
-| TASK-010 | Create JSDoc extraction script using `@microsoft/api-extractor` or similar for component documentation | | |
-| TASK-011 | Implement automated markdown generation from JSDoc comments in `@sparkle/ui` components | | |
+| TASK-010 | Create JSDoc extraction script using `@microsoft/api-extractor` or similar for component documentation | ✅ | 2025-09-07 |
+| TASK-011 | Implement automated markdown generation from JSDoc comments in `@sparkle/ui` components | ✅ | 2025-09-07 |
 | TASK-012 | Set up content collection schemas in `docs/src/content/config.ts` for components, API references, and guides | | |
 | TASK-013 | Create automation scripts in `docs/scripts/` for documentation generation | | |
 | TASK-014 | Configure Astro to use generated documentation content in build process | | |

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -19,3 +19,5 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+src/generated/component-docs.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,9 @@
     "dev": "astro dev",
     "docs:api": "typedoc --options typedoc.json",
     "docs:api:watch": "typedoc --options typedoc.json --watch",
-    "docs:generate": "pnpm docs:api",
+    "docs:extract": "tsx scripts/extract-jsdoc.ts",
+    "docs:generate": "tsx scripts/generate-docs.ts",
+    "docs:markdown": "tsx scripts/generate-markdown.ts",
     "lint": "eslint",
     "preview": "astro preview",
     "start": "astro dev"
@@ -43,7 +45,11 @@
     "sharp": "^0.34.2"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "7.52.11",
     "@types/node": "22.18.0",
+    "doctrine": "3.0.0",
+    "ts-morph": "26.0.0",
+    "tsx": "4.20.5",
     "typedoc": "0.28.12",
     "typedoc-plugin-frontmatter": "1.3.0",
     "typedoc-plugin-markdown": "4.8.1",

--- a/docs/scripts/extract-jsdoc.ts
+++ b/docs/scripts/extract-jsdoc.ts
@@ -1,0 +1,334 @@
+import {existsSync, mkdirSync, writeFileSync} from 'node:fs'
+import {dirname, join, relative} from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+
+import {parse as parseJSDoc, type Annotation} from 'doctrine'
+import {Project, SyntaxKind, type FunctionDeclaration, type VariableDeclaration} from 'ts-morph'
+
+const filename = fileURLToPath(import.meta.url)
+const scriptDir = dirname(filename)
+
+interface ComponentDocumentation {
+  /** Component name */
+  name: string
+  /** File path relative to packages/ui/src */
+  filePath: string
+  /** Component description from JSDoc */
+  description?: string
+  /** JSDoc tags and examples */
+  jsdoc?: Annotation
+  /** Component props interface documentation */
+  props?: PropDocumentation[]
+  /** Usage examples extracted from JSDoc */
+  examples?: string[]
+  /** Whether this is the default export */
+  isDefault: boolean
+}
+
+interface PropDocumentation {
+  /** Property name */
+  name: string
+  /** TypeScript type */
+  type: string
+  /** Whether the prop is required */
+  required: boolean
+  /** Default value if any */
+  defaultValue?: string
+  /** JSDoc description */
+  description?: string
+}
+
+/**
+ * Extracts JSDoc comments and component metadata from @sparkle/ui components
+ */
+export class JSDocExtractor {
+  private project: Project
+  private uiPackagePath: string
+  private outputPath: string
+
+  constructor() {
+    // Initialize TypeScript project for parsing
+    this.project = new Project({
+      tsConfigFilePath: join(scriptDir, '../../packages/ui/tsconfig.json'),
+      skipAddingFilesFromTsConfig: false,
+    })
+
+    this.uiPackagePath = join(scriptDir, '../../packages/ui/src')
+    this.outputPath = join(scriptDir, '../src/content/docs/components')
+
+    // Ensure output directory exists
+    if (!existsSync(this.outputPath)) {
+      mkdirSync(this.outputPath, {recursive: true})
+    }
+  }
+
+  /**
+   * Extracts documentation from all components in the UI package
+   */
+  async extractAll(): Promise<ComponentDocumentation[]> {
+    console.log('🔍 Extracting JSDoc documentation from @sparkle/ui components...')
+
+    const componentFiles = this.project.getSourceFiles().filter(file => {
+      const filePath = file.getFilePath()
+      return (
+        filePath.includes('packages/ui/src/components') &&
+        (filePath.endsWith('.tsx') || filePath.endsWith('.ts')) &&
+        !filePath.includes('.test.') &&
+        !filePath.includes('.stories.') &&
+        !filePath.includes('index.ts')
+      )
+    })
+
+    const documentation: ComponentDocumentation[] = []
+
+    for (const file of componentFiles) {
+      try {
+        const componentDocs = await this.extractFromFile(file.getFilePath())
+        documentation.push(...componentDocs)
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        console.warn(`⚠️  Failed to extract documentation from ${file.getFilePath()}: ${errorMessage}`)
+      }
+    }
+
+    console.log(`✅ Extracted documentation for ${documentation.length} components`)
+    return documentation
+  }
+
+  /**
+   * Extracts documentation from a single TypeScript file
+   */
+  private async extractFromFile(filePath: string): Promise<ComponentDocumentation[]> {
+    const sourceFile = this.project.getSourceFile(filePath)
+    if (!sourceFile) {
+      throw new Error(`Could not load source file: ${filePath}`)
+    }
+
+    const documentation: ComponentDocumentation[] = []
+    const relativeFilePath = relative(this.uiPackagePath, filePath)
+
+    // Find all exported React components (functions with JSX.Element return type or React.forwardRef)
+    const exportedDeclarations = sourceFile.getExportedDeclarations()
+
+    for (const [exportName, declarations] of exportedDeclarations) {
+      for (const declaration of declarations) {
+        // Handle React.forwardRef components
+        if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
+          const variableDeclaration = declaration as VariableDeclaration
+          const initializer = variableDeclaration.getInitializer()
+
+          if (initializer?.getText().includes('React.forwardRef')) {
+            const componentDoc = this.extractComponentDocumentation(exportName, relativeFilePath, variableDeclaration)
+            if (componentDoc) {
+              documentation.push(componentDoc)
+            }
+          }
+        }
+
+        // Handle regular function components
+        if (declaration.getKind() === SyntaxKind.FunctionDeclaration) {
+          const functionDeclaration = declaration as FunctionDeclaration
+          const returnType = functionDeclaration.getReturnType()
+
+          if (this.isReactComponent(returnType.getText())) {
+            const componentDoc = this.extractComponentDocumentation(exportName, relativeFilePath, functionDeclaration)
+            if (componentDoc) {
+              documentation.push(componentDoc)
+            }
+          }
+        }
+      }
+    }
+
+    return documentation
+  }
+
+  /**
+   * Extracts documentation for a specific component declaration
+   */
+  private extractComponentDocumentation(
+    name: string,
+    filePath: string,
+    declaration: VariableDeclaration | FunctionDeclaration,
+  ): ComponentDocumentation | null {
+    try {
+      // Get JSDoc comments using a more robust approach
+      let jsDocTags: any[] = []
+      let description = ''
+      let jsdoc: Annotation | undefined
+      let examples: string[] = []
+
+      // Try multiple approaches to get JSDoc comments
+      // 1. Try getJsDocs() method first
+      try {
+        jsDocTags = (declaration as any).getJsDocs?.() || []
+      } catch {
+        jsDocTags = []
+      }
+
+      // 2. If no JSDoc found via getJsDocs, look for leading comments manually
+      if (jsDocTags.length === 0) {
+        const sourceFile = declaration.getSourceFile()
+        const declarationStart = declaration.getStart()
+
+        // Get all comments in the file
+        const allComments = sourceFile.getFullText().match(/\/\*\*[\s\S]*?\*\//g) || []
+
+        // Find the comment that appears just before this declaration
+        for (const comment of allComments) {
+          const commentIndex = sourceFile.getFullText().indexOf(comment)
+          const commentEnd = commentIndex + comment.length
+
+          // Check if this comment is within ~100 characters before the declaration
+          // (allowing for whitespace and export keywords)
+          if (commentEnd < declarationStart && declarationStart - commentEnd < 100) {
+            // Check if there's mostly whitespace between comment and declaration
+            const betweenText = sourceFile.getFullText().slice(commentEnd, declarationStart)
+            if (/^\s*(?:export\s+)?(?:const\s+)?$/m.test(betweenText)) {
+              try {
+                jsdoc = parseJSDoc(comment, {unwrap: true})
+                if (jsdoc) {
+                  description = jsdoc.description || ''
+                  examples =
+                    jsdoc.tags
+                      ?.filter(tag => tag.title === 'example')
+                      .map(tag => tag.description || '')
+                      .filter(Boolean) || []
+                }
+                break // Found the right comment
+              } catch {
+                // Continue looking for other comments
+              }
+            }
+          }
+        }
+      } else {
+        // Process JSDoc from getJsDocs()
+        const jsDocText = jsDocTags[0].getFullText()
+        jsdoc = parseJSDoc(jsDocText, {unwrap: true})
+
+        if (jsdoc) {
+          description = jsdoc.description || ''
+          examples =
+            jsdoc.tags
+              ?.filter(tag => tag.title === 'example')
+              .map(tag => tag.description || '')
+              .filter(Boolean) || []
+        }
+      }
+
+      // Extract props interface documentation
+      const props = this.extractPropsDocumentation(declaration)
+
+      return {
+        name,
+        filePath,
+        description,
+        jsdoc,
+        props,
+        examples,
+        isDefault: name === 'default',
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      console.warn(`⚠️  Failed to extract documentation for component ${name}: ${errorMessage}`)
+      return null
+    }
+  }
+
+  /**
+   * Extracts props documentation from component interface or type
+   */
+  private extractPropsDocumentation(declaration: VariableDeclaration | FunctionDeclaration): PropDocumentation[] {
+    const props: PropDocumentation[] = []
+
+    try {
+      // For forwardRef components, look for Props interface
+      const sourceFile = declaration.getSourceFile()
+      const componentName = declaration.getName()
+      const propsInterfaceName = `${componentName}Props`
+
+      // Find the props interface
+      const propsInterface = sourceFile.getInterface(propsInterfaceName)
+      if (propsInterface) {
+        const properties = propsInterface.getProperties()
+
+        for (const property of properties) {
+          const propName = property.getName()
+          const typeText = property.getType().getText()
+          const isOptional = property.hasQuestionToken()
+          const jsDocTags = property.getJsDocs()
+
+          let propDescription = ''
+          if (jsDocTags.length > 0) {
+            const jsDocText = jsDocTags[0].getFullText()
+            const parsed = parseJSDoc(jsDocText, {unwrap: true})
+            propDescription = parsed.description || ''
+          }
+
+          // Extract default value from initializer if present
+          let defaultValue: string | undefined
+          const initializer = property.getInitializer?.()
+          if (initializer) {
+            defaultValue = initializer.getText()
+          }
+
+          props.push({
+            name: propName,
+            type: typeText,
+            required: !isOptional,
+            defaultValue,
+            description: propDescription,
+          })
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      console.warn(`⚠️  Failed to extract props for ${declaration.getName()}: ${errorMessage}`)
+    }
+
+    return props
+  }
+
+  /**
+   * Checks if a type string represents a React component
+   */
+  private isReactComponent(typeText: string): boolean {
+    return (
+      typeText.includes('JSX.Element') ||
+      typeText.includes('React.ReactElement') ||
+      typeText.includes('ReactNode') ||
+      typeText.includes('Element')
+    )
+  }
+
+  /**
+   * Saves extracted documentation to JSON file for further processing
+   */
+  async saveDocumentation(documentation: ComponentDocumentation[]): Promise<void> {
+    const outputFile = join(scriptDir, '../src/generated/component-docs.json')
+    const outputDir = dirname(outputFile)
+
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, {recursive: true})
+    }
+
+    writeFileSync(outputFile, JSON.stringify(documentation, null, 2))
+    console.log(`📝 Saved component documentation to ${outputFile}`)
+  }
+}
+
+// CLI execution when run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const extractor = new JSDocExtractor()
+
+  try {
+    const documentation = await extractor.extractAll()
+    await extractor.saveDocumentation(documentation)
+    console.log('🎉 JSDoc extraction completed successfully!')
+  } catch (error) {
+    console.error('❌ JSDoc extraction failed:', error)
+    process.exit(1)
+  }
+}

--- a/docs/scripts/generate-docs.ts
+++ b/docs/scripts/generate-docs.ts
@@ -1,0 +1,37 @@
+import process from 'node:process'
+
+import {JSDocExtractor} from './extract-jsdoc.js'
+import {MarkdownGenerator} from './generate-markdown.js'
+
+/**
+ * Main script that orchestrates JSDoc extraction and Markdown generation
+ */
+async function generateDocumentation(): Promise<void> {
+  console.log('🚀 Starting automated documentation generation...')
+
+  try {
+    // Step 1: Extract JSDoc documentation from components
+    console.log('\n📖 Step 1: Extracting JSDoc from @sparkle/ui components')
+    const extractor = new JSDocExtractor()
+    const documentation = await extractor.extractAll()
+    await extractor.saveDocumentation(documentation)
+
+    // Step 2: Generate Markdown documentation
+    console.log('\n📝 Step 2: Generating Markdown documentation')
+    const generator = new MarkdownGenerator()
+    await generator.generateAll()
+
+    console.log('\n🎉 Documentation generation completed successfully!')
+    console.log('📄 Generated files:')
+    console.log('  - src/generated/component-docs.json (extracted JSDoc data)')
+    console.log('  - src/content/docs/components/*.md (Markdown documentation)')
+  } catch (error) {
+    console.error('\n❌ Documentation generation failed:', error)
+    process.exit(1)
+  }
+}
+
+// CLI execution when run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await generateDocumentation()
+}

--- a/docs/scripts/generate-markdown.ts
+++ b/docs/scripts/generate-markdown.ts
@@ -1,0 +1,352 @@
+import type {Annotation} from 'doctrine'
+
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+
+const filename = fileURLToPath(import.meta.url)
+const scriptDir = dirname(filename)
+
+interface ComponentDocumentation {
+  /** Component name */
+  name: string
+  /** File path relative to packages/ui/src */
+  filePath: string
+  /** Component description from JSDoc */
+  description?: string
+  /** JSDoc tags and examples */
+  jsdoc?: Annotation
+  /** Component props interface documentation */
+  props?: PropDocumentation[]
+  /** Usage examples extracted from JSDoc */
+  examples?: string[]
+  /** Whether this is the default export */
+  isDefault: boolean
+}
+
+interface PropDocumentation {
+  /** Property name */
+  name: string
+  /** TypeScript type */
+  type: string
+  /** Whether the prop is required */
+  required: boolean
+  /** Default value if any */
+  defaultValue?: string
+  /** JSDoc description */
+  description?: string
+}
+
+/**
+ * Generates Markdown documentation from extracted JSDoc component data
+ */
+export class MarkdownGenerator {
+  private outputPath: string
+  private componentDocs: ComponentDocumentation[]
+
+  constructor(componentDocsPath?: string) {
+    this.outputPath = join(scriptDir, '../src/content/docs/components')
+
+    // Load component documentation from JSON file
+    const docsPath = componentDocsPath || join(scriptDir, '../src/generated/component-docs.json')
+
+    if (!existsSync(docsPath)) {
+      throw new Error(`Component documentation file not found: ${docsPath}`)
+    }
+
+    const docsContent = readFileSync(docsPath, 'utf-8')
+    this.componentDocs = JSON.parse(docsContent) as ComponentDocumentation[]
+
+    // Ensure output directory exists
+    if (!existsSync(this.outputPath)) {
+      mkdirSync(this.outputPath, {recursive: true})
+    }
+  }
+
+  /**
+   * Generates markdown documentation for all components
+   */
+  async generateAll(): Promise<void> {
+    console.log('📝 Generating Markdown documentation from JSDoc...')
+
+    // Generate index page for components
+    await this.generateComponentIndex()
+
+    // Generate individual component pages
+    let generatedCount = 0
+    for (const componentDoc of this.componentDocs) {
+      try {
+        await this.generateComponentPage(componentDoc)
+        generatedCount++
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        console.warn(`⚠️  Failed to generate documentation for ${componentDoc.name}: ${errorMessage}`)
+      }
+    }
+
+    console.log(`✅ Generated ${generatedCount} component documentation pages`)
+  }
+
+  /**
+   * Generates the main components index page
+   */
+  private async generateComponentIndex(): Promise<void> {
+    const content = this.buildComponentIndexContent()
+    const outputFile = join(this.outputPath, 'index.md')
+
+    writeFileSync(outputFile, content)
+    console.log(`📄 Generated components index: ${outputFile}`)
+  }
+
+  /**
+   * Generates documentation page for a single component
+   */
+  private async generateComponentPage(componentDoc: ComponentDocumentation): Promise<void> {
+    const content = this.buildComponentPageContent(componentDoc)
+    const filename = this.getComponentFilename(componentDoc.name)
+    const outputFile = join(this.outputPath, filename)
+
+    writeFileSync(outputFile, content)
+    console.log(`📄 Generated component page: ${outputFile}`)
+  }
+
+  /**
+   * Builds the content for the components index page
+   */
+  private buildComponentIndexContent(): string {
+    const sortedComponents = [...this.componentDocs].sort((a, b) => a.name.localeCompare(b.name))
+
+    const componentList = sortedComponents
+      .map(component => {
+        // Normalize description to single line for index
+        const description = component.description
+          ? component.description.replaceAll('\n', ' ').replaceAll(/\s+/g, ' ').trim()
+          : 'No description available'
+        const link = this.getComponentFilename(component.name).replace('.md', '')
+        return `- [${component.name}](./${link}) - ${description}`
+      })
+      .join('\n')
+
+    return `---
+title: UI Components
+description: Complete reference for all Sparkle UI components
+---
+
+# UI Components
+
+This section contains documentation for all components in the \`@sparkle/ui\` package. Each component includes detailed API documentation, usage examples, and interactive demos.
+
+## Available Components
+
+${componentList}
+
+## Getting Started
+
+To use any of these components in your project:
+
+\`\`\`bash
+pnpm add @sparkle/ui @sparkle/theme
+\`\`\`
+
+\`\`\`tsx
+import { Button } from '@sparkle/ui'
+import '@sparkle/ui/styles.css'
+
+export function MyComponent() {
+  return <Button variant="primary">Click me</Button>
+}
+\`\`\`
+
+## Component Patterns
+
+All Sparkle UI components follow these patterns:
+
+- **Theme Integration**: Components use CSS custom properties from \`@sparkle/theme\`
+- **Accessibility**: Built with accessibility best practices and ARIA support
+- **TypeScript**: Full TypeScript support with detailed prop interfaces
+- **Flexible Styling**: Support for custom className props and CSS-in-JS
+- **Forward Refs**: All components properly forward refs for library integration
+`
+  }
+
+  /**
+   * Builds the content for a single component documentation page
+   */
+  private buildComponentPageContent(componentDoc: ComponentDocumentation): string {
+    const {name, description, props = [], examples = []} = componentDoc
+
+    // Build frontmatter with properly escaped description
+    const yamlSafeDescription = (description || `Documentation for the ${name} component`)
+      .replaceAll('\n', ' ')
+      .replaceAll(/\s+/g, ' ')
+      .trim()
+      .replaceAll('"', String.raw`\"`)
+
+    const frontmatter = `---
+title: ${name}
+description: "${yamlSafeDescription}"
+---`
+
+    // Build main content
+    let content = `${frontmatter}
+
+# ${name}
+
+${description || 'No description available'}
+
+## Import
+
+\`\`\`tsx
+import { ${name} } from '@sparkle/ui'
+\`\`\`
+`
+
+    // Add props documentation if available
+    if (props.length > 0) {
+      content += `
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+${props.map(prop => this.formatPropRow(prop)).join('\n')}
+`
+    }
+
+    // Add usage examples
+    if (examples.length > 0) {
+      content += `
+## Examples
+
+${examples
+  .map(
+    (example, index) => `
+### Example ${index + 1}
+
+\`\`\`tsx
+${example}
+\`\`\`
+`,
+  )
+  .join('\n')}
+`
+    } else {
+      // Add basic usage example
+      content += `
+## Basic Usage
+
+\`\`\`tsx
+import { ${name} } from '@sparkle/ui'
+
+export function Example() {
+  return <${name} />
+}
+\`\`\`
+`
+    }
+
+    // Add additional sections
+    content += `
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your \`@sparkle/theme\` configuration
+2. **CSS Classes**: Apply custom CSS classes via the \`className\` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+${this.generateAccessibilityNotes(name)}
+
+## Related Components
+
+${this.generateRelatedComponents(componentDoc)}
+`
+
+    return content
+  }
+
+  /**
+   * Formats a single prop row for the props table
+   */
+  private formatPropRow(prop: PropDocumentation): string {
+    const {name, type, required, defaultValue, description} = prop
+
+    const escapedType = type.replaceAll('|', String.raw`\|`)
+    const requiredText = required ? '✓' : ''
+    const defaultText = defaultValue || ''
+    const descriptionText = description || ''
+
+    return `| \`${name}\` | \`${escapedType}\` | ${requiredText} | \`${defaultText}\` | ${descriptionText} |`
+  }
+
+  /**
+   * Generates accessibility notes for a component
+   */
+  private generateAccessibilityNotes(componentName: string): string {
+    const commonNotes = {
+      Button:
+        'Supports keyboard navigation, focus management, and screen reader announcements. Use semantic button elements for actions.',
+      Form: 'Includes proper form labeling, validation states, and error messaging for screen readers.',
+      Input: 'Provides proper labeling, validation feedback, and keyboard navigation support.',
+    }
+
+    return (
+      commonNotes[componentName as keyof typeof commonNotes] ||
+      'This component follows accessibility best practices with proper ARIA attributes and keyboard support.'
+    )
+  }
+
+  /**
+   * Generates related components section
+   */
+  private generateRelatedComponents(componentDoc: ComponentDocumentation): string {
+    const componentName = componentDoc.name
+    const allComponentNames = this.componentDocs.map(doc => doc.name)
+
+    // Simple heuristic to find related components
+    const related = allComponentNames.filter(name => {
+      if (name === componentName) return false
+
+      // Look for components with similar prefixes (e.g., Form*, Button*)
+      const componentPrefix = componentName.match(/^[A-Z][a-z]+/)?.[0]
+      const namePrefix = name.match(/^[A-Z][a-z]+/)?.[0]
+
+      return componentPrefix && namePrefix && componentPrefix === namePrefix
+    })
+
+    if (related.length === 0) {
+      return 'No directly related components found.'
+    }
+
+    return related
+      .map(name => {
+        const filename = this.getComponentFilename(name).replace('.md', '')
+        return `- [${name}](./${filename})`
+      })
+      .join('\n')
+  }
+
+  /**
+   * Gets the filename for a component documentation page
+   */
+  private getComponentFilename(componentName: string): string {
+    // Convert PascalCase to kebab-case
+    const kebabCase = componentName.replaceAll(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+
+    return `${kebabCase}.md`
+  }
+}
+
+// CLI execution when run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const generator = new MarkdownGenerator()
+    await generator.generateAll()
+    console.log('🎉 Markdown generation completed successfully!')
+  } catch (error) {
+    console.error('❌ Markdown generation failed:', error)
+    process.exit(1)
+  }
+}

--- a/docs/src/content/docs/components/button.md
+++ b/docs/src/content/docs/components/button.md
@@ -1,0 +1,50 @@
+---
+title: Button
+description: "Button component with theme-aware styling and semantic color variants Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports semantic color variants for contextual actions (success, warning, error)."
+---
+
+# Button
+
+Button component with theme-aware styling and semantic color variants
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports semantic color variants for contextual actions (success, warning, error).
+
+## Import
+
+```tsx
+import { Button } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `variant` | `"primary" \| "secondary" \| "outline" \| "ghost" \| undefined` |  | `` | The variant style of the button |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | The size of the button |
+| `semantic` | `"default" \| "success" \| "warning" \| "error" \| undefined` |  | `` | The semantic color variant for contextual styling |
+
+## Basic Usage
+
+```tsx
+import { Button } from '@sparkle/ui'
+
+export function Example() {
+  return <Button />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+Supports keyboard navigation, focus management, and screen reader announcements. Use semantic button elements for actions.
+
+## Related Components
+
+No directly related components found.

--- a/docs/src/content/docs/components/form-control.md
+++ b/docs/src/content/docs/components/form-control.md
@@ -1,0 +1,61 @@
+---
+title: FormControl
+description: "Form control wrapper component with theme-aware styling that handles input focus and validation Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes. Primarily a pass-through wrapper for Radix Form.Control."
+---
+
+# FormControl
+
+Form control wrapper component with theme-aware styling that handles input focus and validation
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes. Primarily a pass-through wrapper for Radix Form.Control.
+
+## Import
+
+```tsx
+import { FormControl } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `asChild` | `boolean \| undefined` |  | `` | Use the child component as the control element |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the control |
+| `validationState` | `"default" \| "success" \| "error" \| undefined` |  | `` | Validation state for styling |
+| `disabled` | `boolean \| undefined` |  | `` | Whether the control is disabled |
+
+## Basic Usage
+
+```tsx
+import { FormControl } from '@sparkle/ui'
+
+export function Example() {
+  return <FormControl />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-description.md
+++ b/docs/src/content/docs/components/form-description.md
@@ -1,0 +1,59 @@
+---
+title: FormDescription
+description: "Form description component with theme-aware styling for providing additional field context Automatically connects to form controls via aria-describedby Uses CSS custom properties from @sparkle/theme for consistent theming."
+---
+
+# FormDescription
+
+Form description component with theme-aware styling for providing additional field context
+
+Automatically connects to form controls via aria-describedby Uses CSS custom properties from @sparkle/theme for consistent theming.
+
+## Import
+
+```tsx
+import { FormDescription } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop       | Type                   | Required | Default | Description                                     |
+| ---------- | ---------------------- | -------- | ------- | ----------------------------------------------- |
+| `children` | `React.ReactNode`      | ✓        | ``      | Description text content                        |
+| `disabled` | `boolean \| undefined` |          | ``      | Whether the description is for a disabled field |
+
+## Basic Usage
+
+```tsx
+import { FormDescription } from '@sparkle/ui'
+
+export function Example() {
+  return <FormDescription />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-field.md
+++ b/docs/src/content/docs/components/form-field.md
@@ -1,0 +1,61 @@
+---
+title: FormField
+description: "Form field wrapper component with theme-aware styling that manages accessibility and validation Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and provides proper field grouping."
+---
+
+# FormField
+
+Form field wrapper component with theme-aware styling that manages accessibility and validation
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and provides proper field grouping.
+
+## Import
+
+```tsx
+import { FormField } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `name` | `string` | ✓ | `` | Field name for form submission and validation |
+| `validationState` | `"default" \| "success" \| "error" \| undefined` |  | `` | Validation state of the field |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the field |
+| `children` | `React.ReactNode` | ✓ | `` | Field children content |
+
+## Basic Usage
+
+```tsx
+import { FormField } from '@sparkle/ui'
+
+export function Example() {
+  return <FormField />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-input.md
+++ b/docs/src/content/docs/components/form-input.md
@@ -1,0 +1,68 @@
+---
+title: FormInput
+description: "Form input component with theme-aware styling for different input types with proper accessibility Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors."
+---
+
+# FormInput
+
+Form input component with theme-aware styling for different input types with proper accessibility
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+
+## Import
+
+```tsx
+import { FormInput } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `type` | `"number" \| "text" \| "email" \| "password" \| "tel" \| "url" \| "search" \| undefined` |  | `` | Input type |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the input |
+| `validationState` | `"default" \| "success" \| "error" \| undefined` |  | `` | Validation state for styling |
+| `placeholder` | `string \| undefined` |  | `` | Input placeholder text |
+| `disabled` | `boolean \| undefined` |  | `` | Whether the field is disabled |
+| `required` | `boolean \| undefined` |  | `` | Whether the field is required |
+| `value` | `string \| undefined` |  | `` | Input value |
+| `onChange` | `((event: React.ChangeEvent<HTMLInputElement>) => void) \| undefined` |  | `` | Input change handler |
+| `onFocus` | `((event: React.FocusEvent<HTMLInputElement, Element>) => void) \| undefined` |  | `` | Input focus handler |
+| `onBlur` | `((event: React.FocusEvent<HTMLInputElement, Element>) => void) \| undefined` |  | `` | Input blur handler |
+| `onKeyDown` | `((event: React.KeyboardEvent<HTMLInputElement>) => void) \| undefined` |  | `` | Input key down handler for keyboard navigation |
+
+## Basic Usage
+
+```tsx
+import { FormInput } from '@sparkle/ui'
+
+export function Example() {
+  return <FormInput />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-label.md
+++ b/docs/src/content/docs/components/form-label.md
@@ -1,0 +1,61 @@
+---
+title: FormLabel
+description: "Form label component with theme-aware styling and proper accessibility associations and required field indicators Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports disabled states."
+---
+
+# FormLabel
+
+Form label component with theme-aware styling and proper accessibility associations and required field indicators
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports disabled states.
+
+## Import
+
+```tsx
+import { FormLabel } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop          | Type                   | Required | Default | Description                             |
+| ------------- | ---------------------- | -------- | ------- | --------------------------------------- |
+| `children`    | `React.ReactNode`      | ✓        | ``      | Label children content                  |
+| `required`    | `boolean \| undefined` |          | ``      | Whether the field is required           |
+| `disabled`    | `boolean \| undefined` |          | ``      | Whether the field is disabled           |
+| `description` | `string \| undefined`  |          | ``      | Optional description text for the field |
+
+## Basic Usage
+
+```tsx
+import { FormLabel } from '@sparkle/ui'
+
+export function Example() {
+  return <FormLabel />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-message.md
+++ b/docs/src/content/docs/components/form-message.md
@@ -1,0 +1,61 @@
+---
+title: FormMessage
+description: "Form message component with theme-aware styling for displaying validation feedback Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports semantic colors for different message types."
+---
+
+# FormMessage
+
+Form message component with theme-aware styling for displaying validation feedback
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports semantic colors for different message types.
+
+## Import
+
+```tsx
+import { FormMessage } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `match` | `"valueMissing" \| "typeMismatch" \| "patternMismatch" \| "tooLong" \| "tooShort" \| "rangeUnderflow" \| "rangeOverflow" \| "stepMismatch" \| "badInput" \| "valid" \| undefined` |  | `` | Built-in validation constraint to match |
+| `children` | `React.ReactNode` | ✓ | `` | Message children content |
+| `announce` | `boolean \| undefined` |  | `` | Whether to announce the message to screen readers |
+| `type` | `"success" \| "error" \| "info" \| undefined` |  | `` | Type of message for styling |
+
+## Basic Usage
+
+```tsx
+import { FormMessage } from '@sparkle/ui'
+
+export function Example() {
+  return <FormMessage />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-password.md
+++ b/docs/src/content/docs/components/form-password.md
@@ -1,0 +1,68 @@
+---
+title: FormPassword
+description: "Form password component with theme-aware styling and optional show/hide toggle Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors."
+---
+
+# FormPassword
+
+Form password component with theme-aware styling and optional show/hide toggle
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+
+## Import
+
+```tsx
+import { FormPassword } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the password input |
+| `validationState` | `"default" \| "success" \| "error" \| undefined` |  | `` | Validation state for styling |
+| `placeholder` | `string \| undefined` |  | `` | Password placeholder text |
+| `disabled` | `boolean \| undefined` |  | `` | Whether the field is disabled |
+| `required` | `boolean \| undefined` |  | `` | Whether the field is required |
+| `showToggle` | `boolean \| undefined` |  | `` | Whether to show the toggle button to reveal/hide password |
+| `value` | `string \| undefined` |  | `` | Input value |
+| `onChange` | `((event: React.ChangeEvent<HTMLInputElement>) => void) \| undefined` |  | `` | Input change handler |
+| `onFocus` | `((event: React.FocusEvent<HTMLInputElement, Element>) => void) \| undefined` |  | `` | Input focus handler |
+| `onBlur` | `((event: React.FocusEvent<HTMLInputElement, Element>) => void) \| undefined` |  | `` | Input blur handler |
+| `onKeyDown` | `((event: React.KeyboardEvent<HTMLInputElement>) => void) \| undefined` |  | `` | Input key down handler for keyboard navigation |
+
+## Basic Usage
+
+```tsx
+import { FormPassword } from '@sparkle/ui'
+
+export function Example() {
+  return <FormPassword />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-select-item.md
+++ b/docs/src/content/docs/components/form-select-item.md
@@ -1,0 +1,50 @@
+---
+title: FormSelectItem
+description: "Documentation for the FormSelectItem component"
+---
+
+# FormSelectItem
+
+No description available
+
+## Import
+
+```tsx
+import { FormSelectItem } from '@sparkle/ui'
+```
+
+## Basic Usage
+
+```tsx
+import { FormSelectItem } from '@sparkle/ui'
+
+export function Example() {
+  return <FormSelectItem />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-select.md
+++ b/docs/src/content/docs/components/form-select.md
@@ -1,0 +1,65 @@
+---
+title: FormSelect
+description: "Form select component with theme-aware styling using Radix UI Select primitives Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors."
+---
+
+# FormSelect
+
+Form select component with theme-aware styling using Radix UI Select primitives
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+
+## Import
+
+```tsx
+import { FormSelect } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the select |
+| `validationState` | `"default" \| "success" \| "error" \| undefined` |  | `` | Validation state for styling |
+| `placeholder` | `string \| undefined` |  | `` | Placeholder text when no value is selected |
+| `disabled` | `boolean \| undefined` |  | `` | Whether the select is disabled |
+| `required` | `boolean \| undefined` |  | `` | Whether the select is required |
+| `value` | `string \| undefined` |  | `` | Select value |
+| `onValueChange` | `((value: string) => void) \| undefined` |  | `` | Select change handler |
+| `children` | `React.ReactNode` | ✓ | `` | Select children (SelectItem components) |
+
+## Basic Usage
+
+```tsx
+import { FormSelect } from '@sparkle/ui'
+
+export function Example() {
+  return <FormSelect />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-submit.md
+++ b/docs/src/content/docs/components/form-submit.md
@@ -1,0 +1,61 @@
+---
+title: FormSubmit
+description: "Form submit button component with theme-aware styling and proper form association Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and follows the same patterns as the Button component."
+---
+
+# FormSubmit
+
+Form submit button component with theme-aware styling and proper form association
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and follows the same patterns as the Button component.
+
+## Import
+
+```tsx
+import { FormSubmit } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the submit button |
+| `variant` | `"primary" \| "secondary" \| "outline" \| undefined` |  | `` | Visual variant for the submit button |
+| `disabled` | `boolean \| undefined` |  | `` | Whether the submit button is disabled |
+| `children` | `React.ReactNode` | ✓ | `` | Submit button children content |
+
+## Basic Usage
+
+```tsx
+import { FormSubmit } from '@sparkle/ui'
+
+export function Example() {
+  return <FormSubmit />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/form-textarea.md
+++ b/docs/src/content/docs/components/form-textarea.md
@@ -1,0 +1,62 @@
+---
+title: FormTextarea
+description: "Form textarea component with theme-aware styling for multi-line text input Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors."
+---
+
+# FormTextarea
+
+Form textarea component with theme-aware styling for multi-line text input
+
+Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+
+## Import
+
+```tsx
+import { FormTextarea } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `size` | `"sm" \| "md" \| "lg" \| undefined` |  | `` | Size variant for the textarea |
+| `validationState` | `"default" \| "success" \| "error" \| undefined` |  | `` | Validation state for styling |
+| `placeholder` | `string \| undefined` |  | `` | Textarea placeholder text |
+| `disabled` | `boolean \| undefined` |  | `` | Whether the textarea is disabled |
+| `required` | `boolean \| undefined` |  | `` | Whether the textarea is required |
+
+## Basic Usage
+
+```tsx
+import { FormTextarea } from '@sparkle/ui'
+
+export function Example() {
+  return <FormTextarea />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+This component follows accessibility best practices with proper ARIA attributes and keyboard support.
+
+## Related Components
+
+- [Form](./form)
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)

--- a/docs/src/content/docs/components/form.md
+++ b/docs/src/content/docs/components/form.md
@@ -1,0 +1,61 @@
+---
+title: Form
+description: "Form component with accessible validation and submission handling"
+---
+
+# Form
+
+Form component with accessible validation and submission handling
+
+## Import
+
+```tsx
+import { Form } from '@sparkle/ui'
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `onSubmit` | `((event: React.FormEvent<HTMLFormElement>) => void) \| undefined` |  | `` | Form submission handler |
+| `clearOnSubmit` | `boolean \| undefined` |  | `` | Clear validation state on form reset |
+| `preventDefaultSubmission` | `boolean \| undefined` |  | `` | Whether to prevent default form submission |
+| `onValidate` | `((formData: FormData) => boolean \| Promise<boolean>) \| undefined` |  | `` | Form validation handler called before submission |
+| `onFormError` | `((error: Error) => void) \| undefined` |  | `` | Error handler for form submission errors |
+| `onFormSuccess` | `((formData: FormData) => void) \| undefined` |  | `` | Success handler for successful form submission |
+
+## Basic Usage
+
+```tsx
+import { Form } from '@sparkle/ui'
+
+export function Example() {
+  return <Form />
+}
+```
+
+## Styling
+
+This component uses theme-aware CSS custom properties for consistent styling across light and dark modes. You can customize the appearance by:
+
+1. **Theme Variables**: Modify theme tokens in your `@sparkle/theme` configuration
+2. **CSS Classes**: Apply custom CSS classes via the `className` prop
+3. **CSS-in-JS**: Use styled-components or emotion with the component
+
+## Accessibility
+
+Includes proper form labeling, validation states, and error messaging for screen readers.
+
+## Related Components
+
+- [FormControl](./form-control)
+- [FormDescription](./form-description)
+- [FormField](./form-field)
+- [FormInput](./form-input)
+- [FormLabel](./form-label)
+- [FormMessage](./form-message)
+- [FormPassword](./form-password)
+- [FormSelect](./form-select)
+- [FormSelectItem](./form-select-item)
+- [FormSubmit](./form-submit)
+- [FormTextarea](./form-textarea)

--- a/docs/src/content/docs/components/index.md
+++ b/docs/src/content/docs/components/index.md
@@ -1,0 +1,51 @@
+---
+title: UI Components
+description: Complete reference for all Sparkle UI components
+---
+
+# UI Components
+
+This section contains documentation for all components in the `@sparkle/ui` package. Each component includes detailed API documentation, usage examples, and interactive demos.
+
+## Available Components
+
+- [Button](./button) - Button component with theme-aware styling and semantic color variants Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports semantic color variants for contextual actions (success, warning, error).
+- [Form](./form) - Form component with accessible validation and submission handling
+- [FormControl](./form-control) - Form control wrapper component with theme-aware styling that handles input focus and validation Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes. Primarily a pass-through wrapper for Radix Form.Control.
+- [FormDescription](./form-description) - Form description component with theme-aware styling for providing additional field context Automatically connects to form controls via aria-describedby Uses CSS custom properties from @sparkle/theme for consistent theming.
+- [FormField](./form-field) - Form field wrapper component with theme-aware styling that manages accessibility and validation Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and provides proper field grouping.
+- [FormInput](./form-input) - Form input component with theme-aware styling for different input types with proper accessibility Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+- [FormLabel](./form-label) - Form label component with theme-aware styling and proper accessibility associations and required field indicators Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports disabled states.
+- [FormMessage](./form-message) - Form message component with theme-aware styling for displaying validation feedback Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports semantic colors for different message types.
+- [FormPassword](./form-password) - Form password component with theme-aware styling and optional show/hide toggle Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+- [FormSelect](./form-select) - Form select component with theme-aware styling using Radix UI Select primitives Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+- [FormSelectItem](./form-select-item) - No description available
+- [FormSubmit](./form-submit) - Form submit button component with theme-aware styling and proper form association Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and follows the same patterns as the Button component.
+- [FormTextarea](./form-textarea) - Form textarea component with theme-aware styling for multi-line text input Uses CSS custom properties from @sparkle/theme for consistent theming across light/dark modes and supports validation states with semantic colors.
+
+## Getting Started
+
+To use any of these components in your project:
+
+```bash
+pnpm add @sparkle/ui @sparkle/theme
+```
+
+```tsx
+import { Button } from '@sparkle/ui'
+import '@sparkle/ui/styles.css'
+
+export function MyComponent() {
+  return <Button variant="primary">Click me</Button>
+}
+```
+
+## Component Patterns
+
+All Sparkle UI components follow these patterns:
+
+- **Theme Integration**: Components use CSS custom properties from `@sparkle/theme`
+- **Accessibility**: Built with accessibility best practices and ARIA support
+- **TypeScript**: Full TypeScript support with detailed prop interfaces
+- **Flexible Styling**: Support for custom className props and CSS-in-JS
+- **Forward Refs**: All components properly forward refs for library integration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,9 +184,21 @@ importers:
         specifier: ^0.34.2
         version: 0.34.3
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 7.52.11
+        version: 7.52.11(@types/node@22.18.0)
       '@types/node':
         specifier: 22.18.0
         version: 22.18.0
+      doctrine:
+        specifier: 3.0.0
+        version: 3.0.0
+      ts-morph:
+        specifier: 26.0.0
+        version: 26.0.0
+      tsx:
+        specifier: 4.20.5
+        version: 4.20.5
       typedoc:
         specifier: 0.28.12
         version: 0.28.12(typescript@5.9.2)
@@ -1914,6 +1926,19 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@microsoft/api-extractor-model@7.30.7':
+    resolution: {integrity: sha512-TBbmSI2/BHpfR9YhQA7nH0nqVmGgJ0xH0Ex4D99/qBDAUpnhA2oikGmdXanbw9AWWY/ExBYIpkmY8dBHdla3YQ==}
+
+  '@microsoft/api-extractor@7.52.11':
+    resolution: {integrity: sha512-IKQ7bHg6f/Io3dQds6r9QPYk4q0OlR9A4nFDtNhUt3UUIhyitbxAqRN1CLjUVtk6IBk3xzyCMOdwwtIXQ7AlGg==}
+    hasBin: true
+
+  '@microsoft/tsdoc-config@0.17.1':
+    resolution: {integrity: sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==}
+
+  '@microsoft/tsdoc@0.15.1':
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -2652,6 +2677,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rushstack/node-core-library@5.14.0':
+    resolution: {integrity: sha512-eRong84/rwQUlATGFW3TMTYVyqL1vfW9Lf10PH+mVGfIb9HzU3h5AASNIw+axnBLjnD0n3rT5uQBwu9fvzATrg==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.5.3':
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
+
+  '@rushstack/terminal@0.15.4':
+    resolution: {integrity: sha512-OQSThV0itlwVNHV6thoXiAYZlQh4Fgvie2CzxFABsbO2MWQsI4zOh3LRNigYSTrmS+ba2j0B3EObakPzf/x6Zg==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.0.2':
+    resolution: {integrity: sha512-+AkJDbu1GFMPIU8Sb7TLVXDv/Q7Mkvx+wAjEl8XiXVVq+p1FmWW6M3LYpJMmoHNckSofeMecgWg5lfMwNAAsEQ==}
+
   '@sentry-internal/tracing@7.120.4':
     resolution: {integrity: sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==}
     engines: {node: '>=8'}
@@ -3027,8 +3074,14 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@ts-morph/common@0.27.0':
+    resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3397,8 +3450,24 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -3415,6 +3484,9 @@ packages:
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
@@ -4017,6 +4089,9 @@ packages:
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -5181,6 +5256,10 @@ packages:
     resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
     engines: {node: '>=0.10.0'}
 
+  fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -5519,6 +5598,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
 
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
@@ -6026,6 +6109,9 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
@@ -6302,6 +6388,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -7065,6 +7155,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -7772,6 +7865,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
@@ -8026,6 +8124,10 @@ packages:
   strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -8317,6 +8419,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-morph@26.0.0:
+    resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
+
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -8464,6 +8569,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -8568,6 +8678,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -9026,6 +9140,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -11120,6 +11237,41 @@ snapshots:
       '@types/react': 19.1.12
       react: 19.1.1
 
+  '@microsoft/api-extractor-model@7.30.7(@types/node@22.18.0)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.14.0(@types/node@22.18.0)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.52.11(@types/node@22.18.0)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.7(@types/node@22.18.0)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.14.0(@types/node@22.18.0)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.15.4(@types/node@22.18.0)
+      '@rushstack/ts-command-line': 5.0.2(@types/node@22.18.0)
+      lodash: 4.17.21
+      minimatch: 10.0.3
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.17.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.10
+
+  '@microsoft/tsdoc@0.15.1': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -11948,6 +12100,40 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.50.0':
     optional: true
 
+  '@rushstack/node-core-library@5.14.0(@types/node@22.18.0)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 22.18.0
+
+  '@rushstack/rig-package@0.5.3':
+    dependencies:
+      resolve: 1.22.10
+      strip-json-comments: 3.1.1
+
+  '@rushstack/terminal@0.15.4(@types/node@22.18.0)':
+    dependencies:
+      '@rushstack/node-core-library': 5.14.0(@types/node@22.18.0)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 22.18.0
+
+  '@rushstack/ts-command-line@5.0.2(@types/node@22.18.0)':
+    dependencies:
+      '@rushstack/terminal': 0.15.4(@types/node@22.18.0)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@sentry-internal/tracing@7.120.4':
     dependencies:
       '@sentry/core': 7.120.4
@@ -12340,10 +12526,18 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@ts-morph/common@0.27.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.0.3
+      path-browserify: 1.0.1
+
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -12741,9 +12935,17 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  ajv-draft-04@1.0.0(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
 
   ajv-keywords@5.1.0(ajv@8.17.1):
     dependencies:
@@ -12758,6 +12960,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
+  ajv@8.13.0:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -13516,6 +13725,8 @@ snapshots:
   clsx@2.1.1: {}
 
   co@4.6.0: {}
+
+  code-block-writer@13.0.3: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -14814,6 +15025,12 @@ snapshots:
 
   fs-exists-sync@0.1.0: {}
 
+  fs-extra@11.3.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -15295,6 +15512,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-lazy@4.0.0: {}
 
   import-local@3.2.0:
     dependencies:
@@ -15993,6 +16212,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jszip@3.10.1:
     dependencies:
       lie: 3.3.0
@@ -16262,6 +16487,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lru-cache@7.18.3: {}
 
@@ -17463,6 +17692,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
@@ -18337,6 +18568,10 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
+
   semver@7.6.3: {}
 
   semver@7.7.2: {}
@@ -18703,6 +18938,8 @@ snapshots:
 
   strict-uri-encode@2.0.0: {}
 
+  string-argv@0.3.2: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -18992,6 +19229,11 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-morph@26.0.0:
+    dependencies:
+      '@ts-morph/common': 0.27.0
+      code-block-writer: 13.0.3
+
   tsconfck@3.1.6(typescript@5.9.2):
     optionalDependencies:
       typescript: 5.9.2
@@ -19124,6 +19366,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.8.2: {}
+
   typescript@5.9.2: {}
 
   ua-parser-js@1.0.41: {}
@@ -19239,6 +19483,8 @@ snapshots:
       unist-util-visit-parents: 6.0.1
 
   universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 
@@ -19610,6 +19856,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 


### PR DESCRIPTION
- Implemented a new script `generate-markdown.ts` to automate the generation of Markdown documentation from JSDoc comments for UI components.
- Created documentation files for the following components:
  - Button
  - Form
  - FormControl
  - FormDescription
  - FormField
  - FormInput
  - FormLabel
  - FormMessage
  - FormPassword
  - FormSelect
  - FormSelectItem
  - FormSubmit
  - FormTextarea
- Added an index page for UI components documentation.
- Updated `pnpm-lock.yaml` to reflect new dependencies.

Relates to TASK-010 and TASK-011 on #872.