### PR TITLE
feat(docs): add Storybook embed component and interactive demos

### DIFF
--- a/.ai/plan/feature-astro-starlight-docs-1.md
+++ b/.ai/plan/feature-astro-starlight-docs-1.md
@@ -88,7 +88,7 @@ This implementation plan outlines the creation of a comprehensive documentation 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
 | TASK-017 | Configure Astro Islands for React component integration in documentation | ✅ | 2025-09-07 |
-| TASK-018 | Create Storybook iframe embed component for displaying interactive component demos | | |
+| TASK-018 | Create Storybook iframe embed component for displaying interactive component demos | ✅ | 2025-09-07 |
 | TASK-019 | Implement live code editor using Monaco Editor with TypeScript support | | |
 | TASK-020 | Build copy-to-clipboard functionality for code examples with visual feedback | | |
 | TASK-021 | Create syntax highlighting system using Shiki for multiple languages | | |

--- a/docs/src/components/common/index.ts
+++ b/docs/src/components/common/index.ts
@@ -1,0 +1,2 @@
+// Common components for the documentation site
+export * from '../interactive'

--- a/docs/src/components/interactive/StorybookEmbed.tsx
+++ b/docs/src/components/interactive/StorybookEmbed.tsx
@@ -1,0 +1,189 @@
+import React, {useEffect, useState} from 'react'
+
+/**
+ * Props for the StorybookEmbed component
+ */
+export interface StorybookEmbedProps {
+  /** The Storybook story ID (e.g., 'components-button--primary') */
+  storyId: string
+  /** Base URL for the Storybook instance, defaults to localhost:6006 for development */
+  storybookUrl?: string
+  /** Height of the iframe in pixels, defaults to 400 */
+  height?: number
+  /** Width of the iframe, defaults to '100%' */
+  width?: string | number
+  /** Whether to show the toolbar in the embedded story, defaults to false */
+  showToolbar?: boolean
+  /** Whether to show the panel (docs, controls, etc.), defaults to false */
+  showPanel?: boolean
+  /** Additional CSS classes for the iframe container */
+  className?: string
+  /** Title for accessibility (screen readers) */
+  title?: string
+  /** Loading state placeholder */
+  loadingPlaceholder?: React.ReactNode
+}
+
+/**
+ * Component that embeds a Storybook story in an iframe for documentation purposes.
+ *
+ * This component provides a seamless way to display interactive Storybook stories
+ * within the Astro Starlight documentation site. It automatically handles the
+ * iframe URL construction, loading states, and responsive behavior.
+ *
+ * @example
+ * ```tsx
+ * // Embed a Button story
+ * <StorybookEmbed
+ *   storyId="components-button--primary"
+ *   title="Primary Button Story"
+ *   height={300}
+ * />
+ *
+ * // Embed with toolbar and controls
+ * <StorybookEmbed
+ *   storyId="components-form--default"
+ *   showToolbar={true}
+ *   showPanel={true}
+ *   height={500}
+ * />
+ * ```
+ */
+export function StorybookEmbed({
+  storyId,
+  storybookUrl = 'http://localhost:6006',
+  height = 400,
+  width = '100%',
+  showToolbar = false,
+  showPanel = false,
+  className = '',
+  title,
+  loadingPlaceholder,
+}: StorybookEmbedProps) {
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+
+  // Construct the iframe URL with proper parameters
+  const iframeUrl = React.useMemo(() => {
+    const url = new URL(`/iframe.html`, storybookUrl)
+    url.searchParams.set('id', storyId)
+    url.searchParams.set('viewMode', 'story')
+
+    // Hide toolbar and panel by default for cleaner embed
+    if (!showToolbar) {
+      url.searchParams.set('nav', '0')
+    }
+    if (!showPanel) {
+      url.searchParams.set('panel', '0')
+    }
+
+    return url.toString()
+  }, [storyId, storybookUrl, showToolbar, showPanel])
+
+  // Generate accessible title if not provided
+  const accessibleTitle = title || `Storybook story: ${storyId.replaceAll('--', ' - ').replaceAll('-', ' ')}`
+
+  // Handle iframe load events
+  const handleLoad = () => {
+    setIsLoading(false)
+    setHasError(false)
+  }
+
+  const handleError = () => {
+    setIsLoading(false)
+    setHasError(true)
+  }
+
+  // Reset loading state when story changes
+  useEffect(() => {
+    setIsLoading(true)
+    setHasError(false)
+  }, [storyId])
+
+  // Default loading placeholder
+  const defaultLoadingPlaceholder = (
+    <div
+      style={{
+        height: `${height}px`,
+        width: typeof width === 'number' ? `${width}px` : width,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#f5f5f5',
+        border: '1px solid #e0e0e0',
+        borderRadius: '8px',
+        fontSize: '14px',
+        color: '#666',
+      }}
+    >
+      Loading Storybook story...
+    </div>
+  )
+
+  // Error state
+  if (hasError) {
+    return (
+      <div
+        style={{
+          height: `${height}px`,
+          width: typeof width === 'number' ? `${width}px` : width,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#fff5f5',
+          border: '1px solid #fed7d7',
+          borderRadius: '8px',
+          padding: '1rem',
+          fontSize: '14px',
+          color: '#e53e3e',
+        }}
+        className={className}
+      >
+        <div style={{marginBottom: '0.5rem', fontWeight: '600'}}>Failed to load Storybook story</div>
+        <div style={{fontSize: '12px', color: '#666', textAlign: 'center'}}>
+          Story ID: {storyId}
+          <br />
+          Make sure Storybook is running and the story exists.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: typeof width === 'number' ? `${width}px` : width,
+        height: `${height}px`,
+      }}
+      className={className}
+    >
+      {/* Loading placeholder */}
+      {isLoading && (
+        <div style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 1}}>
+          {loadingPlaceholder || defaultLoadingPlaceholder}
+        </div>
+      )}
+
+      {/* Storybook iframe */}
+      <iframe
+        src={iframeUrl}
+        width={width}
+        height={height}
+        title={accessibleTitle}
+        style={{
+          border: '1px solid #e0e0e0',
+          borderRadius: '8px',
+          backgroundColor: '#ffffff',
+          opacity: isLoading ? 0 : 1,
+          transition: 'opacity 0.2s ease-in-out',
+        }}
+        onLoad={handleLoad}
+        onError={handleError}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-presentation"
+        loading="lazy"
+      />
+    </div>
+  )
+}

--- a/docs/src/components/interactive/StorybookEmbedAstro.astro
+++ b/docs/src/components/interactive/StorybookEmbedAstro.astro
@@ -1,0 +1,78 @@
+---
+import {StorybookEmbed} from './StorybookEmbed.tsx'
+import type {StorybookEmbedProps} from './StorybookEmbed.tsx'
+
+interface Props extends Omit<StorybookEmbedProps, 'className'> {
+  /**
+   * CSS class names to apply to the container
+   */
+  class?: string
+}
+
+const {
+  storyId,
+  storybookUrl,
+  height = 400,
+  width = '100%',
+  showToolbar = false,
+  showPanel = false,
+  title,
+  class: className = '',
+} = Astro.props
+---
+
+<div class={`storybook-embed-wrapper ${className}`}>
+  <StorybookEmbed
+    client:load
+    storyId={storyId}
+    storybookUrl={storybookUrl}
+    height={height}
+    width={width}
+    showToolbar={showToolbar}
+    showPanel={showPanel}
+    title={title}
+  />
+
+  <!-- Fallback content for when JavaScript is disabled -->
+  <noscript>
+    <div class="storybook-fallback">
+      <p>Interactive Storybook demo requires JavaScript.</p>
+      <a href={storybookUrl || 'http://localhost:6006'} target="_blank" rel="noopener noreferrer">
+        View story: {storyId} in Storybook →
+      </a>
+    </div>
+  </noscript>
+</div>
+
+<style>
+  .storybook-embed-wrapper {
+    margin: 1rem 0;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .storybook-fallback {
+    padding: 2rem;
+    text-align: center;
+    background-color: var(--sl-color-bg-sidebar);
+    border: 1px solid var(--sl-color-hairline-shade);
+    border-radius: 8px;
+  }
+
+  .storybook-fallback a {
+    color: var(--sl-color-text-accent);
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .storybook-fallback a:hover {
+    text-decoration: underline;
+  }
+
+  /* Responsive adjustments */
+  @media (max-width: 768px) {
+    .storybook-embed-wrapper {
+      margin: 0.5rem 0;
+    }
+  }
+</style>

--- a/docs/src/components/interactive/index.ts
+++ b/docs/src/components/interactive/index.ts
@@ -1,0 +1,6 @@
+// Export both the React component and Astro wrapper for different use cases
+export {StorybookEmbed} from './StorybookEmbed.tsx'
+export type {StorybookEmbedProps} from './StorybookEmbed.tsx'
+
+// Astro component is imported via the .astro file when needed
+export const StorybookEmbedAstro = './StorybookEmbedAstro.astro'

--- a/docs/src/content/docs/playground/button-example.mdx
+++ b/docs/src/content/docs/playground/button-example.mdx
@@ -1,0 +1,44 @@
+---
+title: Button Component
+description: Comprehensive button component with theme-aware styling and accessibility features
+---
+
+import StorybookEmbedAstro from '../../../components/interactive/StorybookEmbedAstro.astro'
+
+# Button Component
+
+The Button component provides a flexible, accessible button implementation with full theme integration and multiple style variants.
+
+## Interactive Demo
+
+<StorybookEmbedAstro
+  storyId="components-button--primary"
+  title="Primary Button Demo"
+  height={300}
+/>
+
+## Features
+
+- **Theme Integration**: Fully integrated with the Sparkle theme system
+- **Accessibility**: WCAG 2.1 AA compliant with proper focus management
+- **Multiple Variants**: Primary, secondary, outline, and ghost styles
+- **Size Options**: Small, medium, and large sizes
+- **Interactive States**: Hover, focus, active, and disabled states
+
+## Component API
+
+The Button component accepts all standard HTML button props plus additional styling props.
+
+## Usage
+
+```tsx
+import {Button} from '@sparkle/ui'
+
+export function MyComponent() {
+  return (
+    <Button variant="primary" size="md">
+      Click me
+    </Button>
+  )
+}
+```

--- a/docs/src/content/docs/playground/interactive-demos.mdx
+++ b/docs/src/content/docs/playground/interactive-demos.mdx
@@ -1,0 +1,94 @@
+---
+title: Interactive Component Demos
+description: Live interactive demonstrations of Sparkle components embedded from Storybook
+---
+
+import StorybookEmbedAstro from '../../../components/interactive/StorybookEmbedAstro.astro'
+
+# Interactive Component Demos
+
+This page demonstrates the Storybook iframe embed component for displaying live, interactive component demos within the documentation site.
+
+## Button Component Demo
+
+Here's a live Button component from our Storybook:
+
+<StorybookEmbedAstro
+  storyId="components-button--primary"
+  title="Primary Button Interactive Demo"
+  height={350}
+/>
+
+### Button with Controls Panel
+
+The same Button component with the Storybook controls panel enabled:
+
+<StorybookEmbedAstro
+  storyId="components-button--primary"
+  title="Primary Button with Controls"
+  height={500}
+  showPanel={true}
+  showToolbar={true}
+/>
+
+## Form Component Demo
+
+Interactive form component demonstration:
+
+<StorybookEmbedAstro
+  storyId="components-form--default"
+  title="Form Component Demo"
+  height={400}
+/>
+
+## Theme Demo
+
+Theme switching demonstration:
+
+<StorybookEmbedAstro
+  storyId="theme--light-theme"
+  title="Theme System Demo"
+  height={300}
+/>
+
+## Features
+
+The Storybook embed component provides:
+
+- **Live Interaction**: Full interactive functionality of components
+- **Responsive Design**: Adapts to different screen sizes
+- **Loading States**: Shows loading placeholder while iframe loads
+- **Error Handling**: Graceful fallback when Storybook is unavailable
+- **Accessibility**: Proper ARIA labels and keyboard navigation
+- **Customizable**: Configurable height, width, toolbar, and panel visibility
+- **No JavaScript Fallback**: Links directly to Storybook when JS is disabled
+
+## Usage
+
+Import the Astro component and use it in your documentation:
+
+```astro
+---
+import StorybookEmbedAstro from '../components/interactive/StorybookEmbedAstro.astro'
+---
+
+<StorybookEmbedAstro
+  storyId="components-button--primary"
+  title="Button Demo"
+  height={350}
+  showPanel={true}
+/>
+```
+
+## Configuration Options
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `storyId` | `string` | **required** | Storybook story ID (e.g., 'components-button--primary') |
+| `storybookUrl` | `string` | `'http://localhost:6006'` | Base URL for Storybook instance |
+| `height` | `number` | `400` | Height of iframe in pixels |
+| `width` | `string \| number` | `'100%'` | Width of iframe |
+| `showToolbar` | `boolean` | `false` | Show Storybook toolbar |
+| `showPanel` | `boolean` | `false` | Show controls/docs panel |
+| `title` | `string` | *auto-generated* | Accessibility title |
+| `class` | `string` | `''` | Additional CSS classes |


### PR DESCRIPTION
- Create StorybookEmbed component for embedding interactive demos
- Add StorybookEmbedAstro wrapper for Astro integration
- Update documentation with interactive demos for Button and Form components
- Include loading states and error handling in the embed component

Relates to TASK-018 on #873.