### PR TITLE
feat(docs): add copy-to-clipboard functionality to CodeEditor

### DIFF
--- a/.ai/plan/feature-astro-starlight-docs-1.md
+++ b/.ai/plan/feature-astro-starlight-docs-1.md
@@ -90,7 +90,7 @@ This implementation plan outlines the creation of a comprehensive documentation 
 | TASK-017 | Configure Astro Islands for React component integration in documentation | ✅ | 2025-09-07 |
 | TASK-018 | Create Storybook iframe embed component for displaying interactive component demos | ✅ | 2025-09-07 |
 | TASK-019 | Implement live code editor using Monaco Editor with TypeScript support | ✅ | 2025-09-08 |
-| TASK-020 | Build copy-to-clipboard functionality for code examples with visual feedback | | |
+| TASK-020 | Build copy-to-clipboard functionality for code examples with visual feedback | ✅ | 2025-09-08 |
 | TASK-021 | Create syntax highlighting system using Shiki for multiple languages | | |
 | TASK-022 | Develop component showcase pages with live examples, props tables, and API documentation | | |
 | TASK-023 | Implement responsive preview system showing components at different screen sizes | | |

--- a/docs/src/components/interactive/CodeEditorAstro.astro
+++ b/docs/src/components/interactive/CodeEditorAstro.astro
@@ -5,6 +5,16 @@ import type {CodeEditorProps} from './CodeEditor.tsx'
 export interface Props extends Omit<CodeEditorProps, 'onChange' | 'onValidate' | 'onReady'> {
   /** Title for accessibility and documentation */
   title?: string
+  /** Whether to show the copy button */
+  showCopyButton?: boolean
+  /** Position of the copy button */
+  copyButtonPosition?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
+  /** Copy button size */
+  copyButtonSize?: 'sm' | 'md' | 'lg'
+  /** Copy button variant */
+  copyButtonVariant?: 'default' | 'outline' | 'ghost' | 'minimal'
+  /** Whether to show a header with title and copy button */
+  showHeader?: boolean
 }
 
 const {
@@ -30,6 +40,11 @@ const {
   compilerOptions = {},
   extraLibs = [],
   title,
+  showCopyButton = false,
+  copyButtonPosition = 'top-right',
+  copyButtonSize = 'sm',
+  copyButtonVariant = 'outline',
+  showHeader = false,
 } = Astro.props
 ---
 
@@ -73,6 +88,12 @@ const {
       enableTypeScript={enableTypeScript}
       compilerOptions={compilerOptions}
       extraLibs={extraLibs}
+      title={title}
+      showCopyButton={showCopyButton}
+      copyButtonPosition={copyButtonPosition}
+      copyButtonSize={copyButtonSize}
+      copyButtonVariant={copyButtonVariant}
+      showHeader={showHeader}
       client:only="react"
     />
   </div>

--- a/docs/src/components/interactive/CopyButton.tsx
+++ b/docs/src/components/interactive/CopyButton.tsx
@@ -1,0 +1,310 @@
+import {useCopyToClipboard, type CopyState} from '../../hooks/UseCopyToClipboard'
+
+/**
+ * Props for the CopyButton component
+ */
+export interface CopyButtonProps {
+  /** The text content to copy to clipboard */
+  textToCopy: string
+  /** Custom label for the button when in idle state */
+  label?: string
+  /** Custom label for the button when copying is in progress */
+  copyingLabel?: string
+  /** Custom label for the button when copy was successful */
+  copiedLabel?: string
+  /** Custom label for the button when copy failed */
+  errorLabel?: string
+  /** Additional CSS classes to apply to the button */
+  className?: string
+  /** Button size variant */
+  size?: 'sm' | 'md' | 'lg'
+  /** Button style variant */
+  variant?: 'default' | 'outline' | 'ghost' | 'minimal'
+  /** Whether to show an icon alongside the text */
+  showIcon?: boolean
+  /** Whether the button should be disabled */
+  disabled?: boolean
+  /** Duration in milliseconds to show "copied" state */
+  resetDelay?: number
+  /** Custom aria-label for accessibility */
+  ariaLabel?: string
+  /** Callback function called when copy operation completes */
+  onCopy?: (success: boolean, error?: string | null) => void
+  /** Optional tooltip text to display on hover */
+  title?: string
+}
+
+/**
+ * SVG icons for different copy states
+ */
+const CopyIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+)
+
+const ErrorIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="m15 9-6 6" />
+    <path d="m9 9 6 6" />
+  </svg>
+)
+
+const LoadingIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    className="animate-spin"
+  >
+    <path d="M21 12a9 9 0 11-6.219-8.56" />
+  </svg>
+)
+
+/**
+ * A reusable copy-to-clipboard button component with visual feedback and accessibility support.
+ *
+ * This component provides a user-friendly way to copy text content to the clipboard with
+ * clear visual feedback states (idle, copying, copied, error). It includes proper
+ * accessibility features, keyboard support, and customizable styling options.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <CopyButton textToCopy="Hello, World!" />
+ *
+ * // Custom styling and labels
+ * <CopyButton
+ *   textToCopy={codeContent}
+ *   label="Copy Code"
+ *   copiedLabel="Copied!"
+ *   variant="outline"
+ *   size="sm"
+ *   showIcon={true}
+ *   onCopy={(success, error) => {
+ *     if (success) {
+ *       console.log('Code copied successfully!')
+ *     } else {
+ *       console.error('Copy failed:', error)
+ *     }
+ *   }}
+ * />
+ *
+ * // Minimal style for inline use
+ * <CopyButton
+ *   textToCopy="npm install @sparkle/ui"
+ *   variant="minimal"
+ *   size="sm"
+ *   ariaLabel="Copy install command"
+ * />
+ * ```
+ */
+export const CopyButton: React.FC<CopyButtonProps> = ({
+  textToCopy,
+  label = 'Copy',
+  copyingLabel = 'Copying...',
+  copiedLabel = 'Copied!',
+  errorLabel = 'Failed',
+  className = '',
+  size = 'md',
+  variant = 'default',
+  showIcon = true,
+  disabled = false,
+  resetDelay = 2000,
+  ariaLabel,
+  onCopy,
+  title,
+}) => {
+  const {state, copyToClipboard, error, isCopying} = useCopyToClipboard({
+    resetDelay,
+  })
+
+  const handleCopy = async () => {
+    if (disabled || isCopying) return
+
+    const success = await copyToClipboard(textToCopy)
+    onCopy?.(success, error)
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      handleCopy()
+    }
+  }
+
+  // Dynamic label based on state
+  const getLabel = () => {
+    switch (state) {
+      case 'copying':
+        return copyingLabel
+      case 'copied':
+        return copiedLabel
+      case 'error':
+        return errorLabel
+      default:
+        return label
+    }
+  }
+
+  // Dynamic icon based on state
+  const getIcon = () => {
+    if (!showIcon) return null
+
+    switch (state) {
+      case 'copying':
+        return <LoadingIcon />
+      case 'copied':
+        return <CheckIcon />
+      case 'error':
+        return <ErrorIcon />
+      default:
+        return <CopyIcon />
+    }
+  }
+
+  // CSS classes for different variants and sizes
+  const getButtonClasses = () => {
+    const baseClasses = [
+      'copy-button',
+      'inline-flex',
+      'items-center',
+      'justify-center',
+      'gap-2',
+      'font-medium',
+      'transition-all',
+      'duration-200',
+      'focus:outline-none',
+      'focus:ring-2',
+      'focus:ring-offset-2',
+      'focus:ring-blue-500',
+      'disabled:opacity-50',
+      'disabled:cursor-not-allowed',
+    ]
+
+    // Size variants
+    const sizeClasses = {
+      sm: ['px-2', 'py-1', 'text-xs', 'rounded'],
+      md: ['px-3', 'py-2', 'text-sm', 'rounded-md'],
+      lg: ['px-4', 'py-2', 'text-base', 'rounded-lg'],
+    }
+
+    // Style variants
+    const variantClasses = {
+      default: ['bg-blue-600', 'text-white', 'hover:bg-blue-700', 'active:bg-blue-800', 'border', 'border-blue-600'],
+      outline: [
+        'bg-transparent',
+        'text-blue-600',
+        'border',
+        'border-blue-600',
+        'hover:bg-blue-50',
+        'active:bg-blue-100',
+        'dark:text-blue-400',
+        'dark:border-blue-400',
+        'dark:hover:bg-blue-900/20',
+        'dark:active:bg-blue-900/30',
+      ],
+      ghost: [
+        'bg-transparent',
+        'text-gray-600',
+        'hover:bg-gray-100',
+        'active:bg-gray-200',
+        'dark:text-gray-400',
+        'dark:hover:bg-gray-800',
+        'dark:active:bg-gray-700',
+      ],
+      minimal: [
+        'bg-transparent',
+        'text-gray-500',
+        'hover:text-gray-700',
+        'active:text-gray-900',
+        'dark:text-gray-400',
+        'dark:hover:text-gray-200',
+        'dark:active:text-gray-100',
+        'p-1',
+      ],
+    }
+
+    // State-specific classes
+    const stateClasses: Record<CopyState, string[]> = {
+      copying: ['cursor-wait'],
+      copied: ['text-green-600', 'dark:text-green-400'],
+      error: ['text-red-600', 'dark:text-red-400'],
+      idle: [],
+    }
+
+    return [
+      ...baseClasses,
+      ...(variant === 'minimal' ? [] : sizeClasses[size]),
+      ...variantClasses[variant],
+      ...(stateClasses[state] || []),
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ')
+  }
+
+  return (
+    <button
+      type="button"
+      className={getButtonClasses()}
+      onClick={handleCopy}
+      onKeyDown={handleKeyDown}
+      disabled={disabled || isCopying}
+      aria-label={ariaLabel || `${getLabel()} to clipboard`}
+      aria-live="polite"
+      aria-atomic="true"
+      title={title || `${getLabel()} to clipboard${error ? `: ${error}` : ''}`}
+    >
+      {getIcon()}
+      <span className={showIcon ? '' : 'sr-only'}>{getLabel()}</span>
+    </button>
+  )
+}
+
+// Default export for Astro compatibility
+export default CopyButton

--- a/docs/src/components/interactive/index.ts
+++ b/docs/src/components/interactive/index.ts
@@ -2,6 +2,9 @@
 export {CodeEditor} from './CodeEditor.tsx'
 export type {CodeEditorProps} from './CodeEditor.tsx'
 
+export {CopyButton} from './CopyButton.tsx'
+export type {CopyButtonProps} from './CopyButton.tsx'
+
 export {StorybookEmbed} from './StorybookEmbed.tsx'
 export type {StorybookEmbedProps} from './StorybookEmbed.tsx'
 

--- a/docs/src/content/docs/playground/copy-demo.mdx
+++ b/docs/src/content/docs/playground/copy-demo.mdx
@@ -1,0 +1,248 @@
+---
+title: Code Editor with Copy
+description: Interactive Monaco Editor with copy-to-clipboard functionality and visual feedback.
+sidebar:
+  label: Copy Feature Demo
+  order: 4
+---
+
+import CodeEditorAstro from '../../../components/interactive/CodeEditorAstro.astro'
+
+# Code Editor with Copy Functionality
+
+Explore the enhanced Monaco Editor with integrated copy-to-clipboard functionality. This demonstrates TASK-020 implementation with visual feedback and multiple positioning options.
+
+## Basic Copy Button (Top Right)
+
+The copy button appears in the top-right corner by default when enabled.
+
+<CodeEditorAstro
+  defaultValue={`// Click the copy button in the top-right corner!
+const message: string = 'Hello, Sparkle!'
+const features: string[] = [
+  'TypeScript Support',
+  'Copy to Clipboard',
+  'Visual Feedback',
+  'Multiple Positions'
+]
+
+function displayFeatures(features: string[]): void {
+  console.log('Sparkle Features:')
+  features.forEach((feature, index) => {
+    console.log(\`\${index + 1}. \${feature}\`)
+  })
+}
+
+displayFeatures(features)
+console.log(message)`}
+  language="typescript"
+  height={300}
+  showCopyButton={true}
+  copyButtonPosition="top-right"
+  copyButtonVariant="outline"
+  copyButtonSize="sm"
+/>
+
+## Header with Copy Button
+
+When using a header, the copy button integrates seamlessly with the title bar.
+
+<CodeEditorAstro
+  defaultValue={`// React component example with copy functionality
+import React, { useState } from 'react'
+
+interface CounterProps {
+  initialValue?: number
+  step?: number
+}
+
+export const Counter: React.FC<CounterProps> = ({
+  initialValue = 0,
+  step = 1
+}) => {
+  const [count, setCount] = useState(initialValue)
+
+  const increment = () => setCount(prev => prev + step)
+  const decrement = () => setCount(prev => prev - step)
+  const reset = () => setCount(initialValue)
+
+  return (
+    <div className="counter">
+      <p>Count: {count}</p>
+      <button onClick={increment}>+{step}</button>
+      <button onClick={decrement}>-{step}</button>
+      <button onClick={reset}>Reset</button>
+    </div>
+  )
+}`}
+  language="tsx"
+  height={400}
+  title="React Counter Component"
+  showHeader={true}
+  showCopyButton={true}
+  copyButtonVariant="default"
+  copyButtonSize="sm"
+/>
+
+## Bottom Right Position
+
+Copy button positioned at the bottom-right corner.
+
+<CodeEditorAstro
+  defaultValue={`// Utility functions with TypeScript
+export const StringUtils = {
+  capitalize: (str: string): string =>
+    str.charAt(0).toUpperCase() + str.slice(1).toLowerCase(),
+
+  truncate: (str: string, maxLength: number): string =>
+    str.length > maxLength ? str.slice(0, maxLength) + '...' : str,
+
+  slugify: (str: string): string =>
+    str.toLowerCase()
+       .replace(/[^a-z0-9 -]/g, '')
+       .replace(/\s+/g, '-')
+       .replace(/-+/g, '-'),
+
+  isEmail: (str: string): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    return emailRegex.test(str)
+  }
+}
+
+// Usage examples
+console.log(StringUtils.capitalize('hello world'))
+console.log(StringUtils.truncate('This is a long text', 10))
+console.log(StringUtils.slugify('Hello World 123!'))
+console.log(StringUtils.isEmail('user@example.com'))`}
+  language="typescript"
+  height={350}
+  showCopyButton={true}
+  copyButtonPosition="bottom-right"
+  copyButtonVariant="ghost"
+  copyButtonSize="md"
+/>
+
+## Bottom Left Position
+
+Copy button positioned at the bottom-left corner.
+
+<CodeEditorAstro
+  defaultValue={`// API client with error handling
+class ApiClient {
+  private baseUrl: string
+  private defaultHeaders: Record<string, string>
+
+  constructor(baseUrl: string, apiKey?: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, '')
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+      ...(apiKey && { 'Authorization': \`Bearer \${apiKey}\` })
+    }
+  }
+
+  async get<T>(endpoint: string): Promise<T> {
+    return this.request<T>('GET', endpoint)
+  }
+
+  async post<T>(endpoint: string, data?: unknown): Promise<T> {
+    return this.request<T>('POST', endpoint, data)
+  }
+
+  private async request<T>(
+    method: string,
+    endpoint: string,
+    data?: unknown
+  ): Promise<T> {
+    const url = \`\${this.baseUrl}\${endpoint}\`
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: this.defaultHeaders,
+        ...(data && { body: JSON.stringify(data) })
+      })
+
+      if (!response.ok) {
+        throw new Error(\`HTTP \${response.status}: \${response.statusText}\`)
+      }
+
+      return await response.json()
+    } catch (error) {
+      console.error('API request failed:', error)
+      throw error
+    }
+  }
+}`}
+  language="typescript"
+  height={400}
+  showCopyButton={true}
+  copyButtonPosition="bottom-left"
+  copyButtonVariant="minimal"
+  copyButtonSize="sm"
+/>
+
+## Multiple Copy Button Variants
+
+Different styling options for the copy button:
+
+### Default Variant
+<CodeEditorAstro
+  defaultValue={`const example = 'Default button style with solid background'`}
+  language="typescript"
+  height={100}
+  showCopyButton={true}
+  copyButtonVariant="default"
+  copyButtonSize="md"
+/>
+
+### Outline Variant
+<CodeEditorAstro
+  defaultValue={`const example = 'Outline button style with border'`}
+  language="typescript"
+  height={100}
+  showCopyButton={true}
+  copyButtonVariant="outline"
+  copyButtonSize="md"
+/>
+
+### Ghost Variant
+<CodeEditorAstro
+  defaultValue={`const example = 'Ghost button style with subtle background'`}
+  language="typescript"
+  height={100}
+  showCopyButton={true}
+  copyButtonVariant="ghost"
+  copyButtonSize="md"
+/>
+
+### Minimal Variant
+<CodeEditorAstro
+  defaultValue={`const example = 'Minimal button style, very subtle'`}
+  language="typescript"
+  height={100}
+  showCopyButton={true}
+  copyButtonVariant="minimal"
+  copyButtonSize="sm"
+/>
+
+## Features Demonstrated
+
+✅ **Copy to Clipboard**: Click any copy button to copy the code content
+✅ **Visual Feedback**: Button states change to show copy progress (copying → copied → back to idle)
+✅ **Error Handling**: Graceful fallback for older browsers
+✅ **Flexible Positioning**: Top/bottom, left/right corner options
+✅ **Style Variants**: Default, outline, ghost, and minimal button styles
+✅ **Size Options**: Small, medium, and large button sizes
+✅ **Header Integration**: Copy button can be integrated into a title header
+✅ **Accessibility**: Proper ARIA labels and keyboard support
+
+## Implementation Notes
+
+This copy functionality is implemented as part of TASK-020 in the Astro Starlight documentation site. The implementation includes:
+
+- **useCopyToClipboard Hook**: Manages clipboard operations with fallback support
+- **CopyButton Component**: Reusable button with visual feedback states
+- **Enhanced CodeEditor**: Monaco Editor with integrated copy functionality
+- **Astro Integration**: Seamless integration with Astro Starlight
+
+The copy functionality uses the modern Clipboard API when available and falls back to the legacy `execCommand` method for broader browser support.

--- a/docs/src/hooks/UseCopyToClipboard.ts
+++ b/docs/src/hooks/UseCopyToClipboard.ts
@@ -1,0 +1,177 @@
+import {useCallback, useState} from 'react'
+
+/**
+ * State of the copy operation
+ */
+export type CopyState = 'idle' | 'copying' | 'copied' | 'error'
+
+/**
+ * Options for the copy-to-clipboard hook
+ */
+export interface UseCopyToClipboardOptions {
+  /** Duration in milliseconds to show "copied" state before returning to idle */
+  resetDelay?: number
+  /** Custom error message to display on copy failure */
+  errorMessage?: string
+  /** Whether to use the legacy execCommand fallback if Clipboard API is unavailable */
+  useFallback?: boolean
+}
+
+/**
+ * Return type for the copy-to-clipboard hook
+ */
+export interface UseCopyToClipboardResult {
+  /** Current state of the copy operation */
+  state: CopyState
+  /** Function to copy text to clipboard */
+  copyToClipboard: (text: string) => Promise<boolean>
+  /** Error message if copy operation failed */
+  error: string | null
+  /** Whether the copy operation is currently in progress */
+  isCopying: boolean
+  /** Whether the copy operation was successful */
+  isCopied: boolean
+  /** Whether the copy operation failed */
+  isError: boolean
+}
+
+/**
+ * Custom hook for copying text to clipboard with visual feedback states.
+ *
+ * This hook provides a comprehensive clipboard copy functionality with proper
+ * error handling, fallback support, and state management for UI feedback.
+ * It uses the modern Clipboard API when available and falls back to the
+ * legacy execCommand method for broader browser support.
+ *
+ * @param options Configuration options for the copy behavior
+ * @returns Object containing copy function and state information
+ *
+ * @example
+ * ```tsx
+ * function CopyExample() {
+ *   const { copyToClipboard, state, error } = useCopyToClipboard({
+ *     resetDelay: 2000,
+ *     useFallback: true
+ *   })
+ *
+ *   const handleCopy = async () => {
+ *     const success = await copyToClipboard('Hello, World!')
+ *     if (!success) {
+ *       console.error('Failed to copy:', error)
+ *     }
+ *   }
+ *
+ *   return (
+ *     <button onClick={handleCopy} disabled={state === 'copying'}>
+ *       {state === 'copied' ? 'Copied!' : 'Copy'}
+ *     </button>
+ *   )
+ * }
+ * ```
+ */
+export function useCopyToClipboard(options: UseCopyToClipboardOptions = {}): UseCopyToClipboardResult {
+  const {resetDelay = 2000, errorMessage = 'Failed to copy to clipboard', useFallback = true} = options
+
+  const [state, setState] = useState<CopyState>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const copyToClipboard = useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!text) {
+        setError('No text provided to copy')
+        setState('error')
+        return false
+      }
+
+      setState('copying')
+      setError(null)
+
+      try {
+        // Try modern Clipboard API first
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text)
+          setState('copied')
+
+          // Reset to idle state after delay
+          setTimeout(() => {
+            setState('idle')
+          }, resetDelay)
+
+          return true
+        }
+
+        // Fallback to legacy execCommand method
+        if (useFallback && typeof document.execCommand === 'function') {
+          const success = await copyWithExecCommand(text)
+          if (success) {
+            setState('copied')
+
+            // Reset to idle state after delay
+            setTimeout(() => {
+              setState('idle')
+            }, resetDelay)
+
+            return true
+          }
+        }
+
+        throw new Error('Clipboard API not available and fallback disabled')
+      } catch (error_) {
+        const errorMsg = error_ instanceof Error ? error_.message : errorMessage
+        setError(errorMsg)
+        setState('error')
+
+        // Reset to idle state after delay
+        setTimeout(() => {
+          setState('idle')
+          setError(null)
+        }, resetDelay)
+
+        return false
+      }
+    },
+    [resetDelay, errorMessage, useFallback],
+  )
+
+  return {
+    state,
+    copyToClipboard,
+    error,
+    isCopying: state === 'copying',
+    isCopied: state === 'copied',
+    isError: state === 'error',
+  }
+}
+
+/**
+ * Legacy fallback method using execCommand for copying text.
+ * This method creates a temporary textarea element, selects the text,
+ * and uses document.execCommand('copy') to copy it to the clipboard.
+ *
+ * @param text The text to copy to clipboard
+ * @returns Promise that resolves to true if successful, false otherwise
+ */
+async function copyWithExecCommand(text: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-999999px'
+    textarea.style.top = '-999999px'
+    textarea.setAttribute('aria-hidden', 'true')
+    textarea.setAttribute('tabindex', '-1')
+
+    document.body.append(textarea)
+
+    try {
+      textarea.select()
+      textarea.setSelectionRange(0, text.length)
+      const success = document.execCommand('copy')
+      resolve(success)
+    } catch {
+      resolve(false)
+    } finally {
+      textarea.remove()
+    }
+  })
+}

--- a/docs/src/hooks/UseToast.tsx
+++ b/docs/src/hooks/UseToast.tsx
@@ -1,0 +1,327 @@
+import {useCallback, useEffect, useState} from 'react'
+
+/**
+ * Toast notification type
+ */
+export type ToastType = 'success' | 'error' | 'warning' | 'info'
+
+/**
+ * Toast notification interface
+ */
+export interface Toast {
+  id: string
+  message: string
+  type: ToastType
+  duration?: number
+  isVisible?: boolean
+}
+
+/**
+ * Options for showing a toast
+ */
+export interface ShowToastOptions {
+  type?: ToastType
+  duration?: number
+}
+
+/**
+ * Return type for the toast hook
+ */
+export interface UseToastResult {
+  /** Array of current toasts */
+  toasts: Toast[]
+  /** Function to show a new toast */
+  showToast: (message: string, options?: ShowToastOptions) => string
+  /** Function to hide a specific toast */
+  hideToast: (id: string) => void
+  /** Function to hide all toasts */
+  clearToasts: () => void
+}
+
+/**
+ * Custom hook for managing toast notifications with auto-dismiss functionality.
+ *
+ * This hook provides a simple toast notification system with support for different
+ * types, custom durations, and automatic dismissal. It's designed to be lightweight
+ * and easy to integrate into any component.
+ *
+ * @param defaultDuration Default duration in milliseconds before auto-dismiss
+ * @returns Object containing toasts array and management functions
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { toasts, showToast, hideToast } = useToast(3000)
+ *
+ *   const handleCopy = async () => {
+ *     const success = await copyToClipboard('Hello')
+ *     if (success) {
+ *       showToast('Copied to clipboard!', { type: 'success' })
+ *     } else {
+ *       showToast('Failed to copy', { type: 'error' })
+ *     }
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <button onClick={handleCopy}>Copy</button>
+ *       <ToastContainer toasts={toasts} onHide={hideToast} />
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export function useToast(defaultDuration = 3000): UseToastResult {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const hideToast = useCallback((id: string) => {
+    setToasts(currentToasts => currentToasts.map(toast => (toast.id === id ? {...toast, isVisible: false} : toast)))
+
+    // Remove from array after animation completes
+    setTimeout(() => {
+      setToasts(currentToasts => currentToasts.filter(toast => toast.id !== id))
+    }, 300)
+  }, [])
+
+  const clearToasts = useCallback(() => {
+    setToasts([])
+  }, [])
+
+  const showToast = useCallback(
+    (message: string, options: ShowToastOptions = {}): string => {
+      const {type = 'info', duration = defaultDuration} = options
+      const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
+      const newToast: Toast = {
+        id,
+        message,
+        type,
+        duration,
+        isVisible: true,
+      }
+
+      setToasts(currentToasts => [...currentToasts, newToast])
+
+      // Auto-dismiss after duration
+      if (duration > 0) {
+        setTimeout(() => {
+          hideToast(id)
+        }, duration)
+      }
+
+      return id
+    },
+    [defaultDuration, hideToast],
+  )
+
+  return {
+    toasts,
+    showToast,
+    hideToast,
+    clearToasts,
+  }
+}
+
+/**
+ * Props for individual toast component
+ */
+export interface ToastItemProps {
+  toast: Toast
+  onHide: (id: string) => void
+}
+
+/**
+ * Individual toast notification component with animations and styling.
+ */
+export const ToastItem: React.FC<ToastItemProps> = ({toast, onHide}) => {
+  const [isExiting, setIsExiting] = useState(false)
+
+  useEffect(() => {
+    if (!toast.isVisible && !isExiting) {
+      setIsExiting(true)
+    }
+  }, [toast.isVisible, isExiting])
+
+  const getToastClasses = () => {
+    const baseClasses = [
+      'relative',
+      'flex',
+      'items-center',
+      'gap-3',
+      'px-4',
+      'py-3',
+      'rounded-lg',
+      'shadow-lg',
+      'border',
+      'transition-all',
+      'duration-300',
+      'transform',
+      'max-w-sm',
+    ]
+
+    const typeClasses = {
+      success: [
+        'bg-green-50',
+        'border-green-200',
+        'text-green-800',
+        'dark:bg-green-900/20',
+        'dark:border-green-700',
+        'dark:text-green-300',
+      ],
+      error: [
+        'bg-red-50',
+        'border-red-200',
+        'text-red-800',
+        'dark:bg-red-900/20',
+        'dark:border-red-700',
+        'dark:text-red-300',
+      ],
+      warning: [
+        'bg-yellow-50',
+        'border-yellow-200',
+        'text-yellow-800',
+        'dark:bg-yellow-900/20',
+        'dark:border-yellow-700',
+        'dark:text-yellow-300',
+      ],
+      info: [
+        'bg-blue-50',
+        'border-blue-200',
+        'text-blue-800',
+        'dark:bg-blue-900/20',
+        'dark:border-blue-700',
+        'dark:text-blue-300',
+      ],
+    }
+
+    const animationClasses =
+      isExiting || !toast.isVisible
+        ? ['opacity-0', 'translate-x-full', 'scale-95']
+        : ['opacity-100', 'translate-x-0', 'scale-100']
+
+    return [...baseClasses, ...typeClasses[toast.type], ...animationClasses].join(' ')
+  }
+
+  const getIcon = () => {
+    const iconClasses = 'w-5 h-5 flex-shrink-0'
+
+    switch (toast.type) {
+      case 'success':
+        return (
+          <svg className={iconClasses} fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )
+      case 'error':
+        return (
+          <svg className={iconClasses} fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )
+      case 'warning':
+        return (
+          <svg className={iconClasses} fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path
+              fillRule="evenodd"
+              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )
+      case 'info':
+      default:
+        return (
+          <svg className={iconClasses} fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )
+    }
+  }
+
+  return (
+    <div className={getToastClasses()} role="alert" aria-live="polite">
+      {getIcon()}
+      <p className="text-sm font-medium flex-1">{toast.message}</p>
+      <button
+        type="button"
+        className="flex-shrink-0 ml-auto pl-3 hover:opacity-70 transition-opacity"
+        onClick={() => onHide(toast.id)}
+        aria-label="Dismiss notification"
+      >
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <path
+            fillRule="evenodd"
+            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Props for the toast container
+ */
+export interface ToastContainerProps {
+  toasts: Toast[]
+  onHide: (id: string) => void
+  position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'top-center' | 'bottom-center'
+  className?: string
+}
+
+/**
+ * Container component for displaying multiple toast notifications.
+ *
+ * This component handles the positioning and layout of multiple toasts,
+ * providing a clean and accessible notification system.
+ */
+export const ToastContainer: React.FC<ToastContainerProps> = ({
+  toasts,
+  onHide,
+  position = 'top-right',
+  className = '',
+}) => {
+  if (toasts.length === 0) return null
+
+  const getPositionClasses = () => {
+    const baseClasses = 'fixed z-50 flex flex-col gap-2 p-4'
+
+    switch (position) {
+      case 'top-left':
+        return `${baseClasses} top-0 left-0`
+      case 'top-right':
+        return `${baseClasses} top-0 right-0`
+      case 'top-center':
+        return `${baseClasses} top-0 left-1/2 transform -translate-x-1/2`
+      case 'bottom-left':
+        return `${baseClasses} bottom-0 left-0`
+      case 'bottom-right':
+        return `${baseClasses} bottom-0 right-0`
+      case 'bottom-center':
+        return `${baseClasses} bottom-0 left-1/2 transform -translate-x-1/2`
+      default:
+        return `${baseClasses} top-0 right-0`
+    }
+  }
+
+  return (
+    <div className={`${getPositionClasses()} ${className}`} aria-label="Notifications">
+      {toasts.map(toast => (
+        <ToastItem key={toast.id} toast={toast} onHide={onHide} />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
- Added CopyButton component for copying text with various states (idle, copying, copied, error).
- Integrated CopyButton into CodeEditor with customizable position, size, and variant options.
- Enhanced CodeEditorAstro to support copy button features and header integration.
- Created useCopyToClipboard hook for managing clipboard operations and state.
- Developed toast notification system for user feedback on copy actions.
- Updated playground documentation to showcase new copy functionality with examples.

Relates to TASK-020 on #873.