### PR TITLE
feat(docs): add Button and Form component documentation

### DIFF
--- a/.ai/plan/feature-astro-starlight-docs-1.md
+++ b/.ai/plan/feature-astro-starlight-docs-1.md
@@ -92,7 +92,7 @@ This implementation plan outlines the creation of a comprehensive documentation 
 | TASK-019 | Implement live code editor using Monaco Editor with TypeScript support | ✅ | 2025-09-08 |
 | TASK-020 | Build copy-to-clipboard functionality for code examples with visual feedback | ✅ | 2025-09-08 |
 | TASK-021 | Create syntax highlighting system using Shiki for multiple languages | | |
-| TASK-022 | Develop component showcase pages with live examples, props tables, and API documentation | | |
+| TASK-022 | Develop component showcase pages with live examples, props tables, and API documentation | ✅ | 2025-09-08 |
 | TASK-023 | Implement responsive preview system showing components at different screen sizes | | |
 | TASK-024 | Create theme toggle integration allowing users to preview components in light/dark modes | | |
 

--- a/docs/src/components/showcase/ComponentShowcase.astro
+++ b/docs/src/components/showcase/ComponentShowcase.astro
@@ -1,0 +1,301 @@
+---
+import type {ComponentDocumentation, ExampleConfig} from './ComponentShowcase'
+
+export interface Props {
+  /** Component name to load documentation for */
+  componentName: string
+  /** Live examples configuration */
+  examples: ExampleConfig[]
+  /** Optional Storybook story ID */
+  storybookId?: string
+  /** Additional CSS classes */
+  className?: string
+}
+
+const {componentName, examples, storybookId, className} = Astro.props
+
+// Load component documentation from generated JSON
+let documentation: ComponentDocumentation | null = null
+
+try {
+  const componentDocsModule = await import('../../generated/component-docs.json')
+  const allDocs = componentDocsModule.default as ComponentDocumentation[]
+  documentation = allDocs.find(doc => doc.name === componentName) || null
+} catch (error) {
+  console.warn(`Failed to load documentation for ${componentName}:`, error)
+}
+
+// If no documentation found, create a minimal structure
+if (!documentation) {
+  documentation = {
+    name: componentName,
+    filePath: `components/${componentName}/${componentName}.tsx`,
+    description: `Documentation for ${componentName} component`,
+    props: [],
+    examples: [],
+    isDefault: false,
+  }
+}
+---
+
+<div class="component-showcase-wrapper">
+  <!-- Use Astro's client:load directive for React component -->
+  <div
+    id={`showcase-${componentName.toLowerCase()}`}
+    data-component-name={componentName}
+    data-documentation={JSON.stringify(documentation)}
+    data-examples={JSON.stringify(examples)}
+    data-storybook-id={storybookId}
+    data-class-name={className}
+  >
+    <!-- This will be replaced by React component via client-side script -->
+    <div class="showcase-loading">
+      <p>Loading {componentName} showcase...</p>
+    </div>
+  </div>
+</div>
+
+<script>
+  import React from 'react'
+  import {createRoot} from 'react-dom/client'
+  import {ComponentShowcase} from './ComponentShowcase'
+
+  // Initialize showcase on page load
+  document.addEventListener('DOMContentLoaded', () => {
+    const showcaseElements = document.querySelectorAll('[data-component-name]')
+
+    showcaseElements.forEach((element) => {
+      const componentName = element.getAttribute('data-component-name')
+      const documentationData = element.getAttribute('data-documentation')
+      const examplesData = element.getAttribute('data-examples')
+      const storybookId = element.getAttribute('data-storybook-id')
+      const className = element.getAttribute('data-class-name')
+
+      if (componentName && documentationData && examplesData) {
+        try {
+          const documentation = JSON.parse(documentationData)
+          const examples = JSON.parse(examplesData)
+
+          const root = createRoot(element)
+          root.render(
+            React.createElement(ComponentShowcase, {
+              documentation,
+              examples,
+              storybookId: storybookId || undefined,
+              className: className || undefined
+            })
+          )
+        } catch (error) {
+          console.error(`Failed to render showcase for ${componentName}:`, error)
+          element.innerHTML = `<p class="error">Failed to load ${componentName} showcase</p>`
+        }
+      }
+    })
+  })
+</script>
+
+<style>
+  .component-showcase-wrapper {
+    @apply w-full;
+  }
+
+  /* Component Showcase Styles */
+  :global(.component-showcase) {
+    @apply space-y-8;
+  }
+
+  /* Header Styles */
+  :global(.showcase-header) {
+    @apply border-b border-gray-200 pb-6 dark:border-gray-700;
+  }
+
+  :global(.component-title) {
+    @apply text-3xl font-bold text-gray-900 dark:text-white mb-2;
+  }
+
+  :global(.component-description) {
+    @apply text-lg text-gray-600 dark:text-gray-300 mb-4 leading-relaxed;
+  }
+
+  :global(.component-meta) {
+    @apply flex items-center gap-3 text-sm;
+  }
+
+  :global(.file-path) {
+    @apply font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded;
+  }
+
+  :global(.default-export-badge) {
+    @apply bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 px-2 py-1 rounded text-xs font-medium;
+  }
+
+  /* Examples Section */
+  :global(.examples-section) {
+    @apply space-y-4;
+  }
+
+  :global(.section-header) {
+    @apply flex items-center justify-between mb-4;
+  }
+
+  :global(.section-header h2) {
+    @apply text-2xl font-semibold text-gray-900 dark:text-white;
+  }
+
+  :global(.example-tabs) {
+    @apply flex space-x-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-lg;
+  }
+
+  :global(.example-tab) {
+    @apply px-4 py-2 rounded-md text-sm font-medium transition-colors;
+    @apply text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white;
+  }
+
+  :global(.example-tab.active) {
+    @apply bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm;
+  }
+
+  :global(.example-content) {
+    @apply space-y-4;
+  }
+
+  :global(.example-header) {
+    @apply flex items-start justify-between;
+  }
+
+  :global(.example-header h3) {
+    @apply text-xl font-semibold text-gray-900 dark:text-white;
+  }
+
+  :global(.example-description) {
+    @apply text-gray-600 dark:text-gray-300 mt-1;
+  }
+
+  :global(.example-controls) {
+    @apply flex items-center gap-2;
+  }
+
+  :global(.toggle-code-btn) {
+    @apply px-3 py-1 text-sm font-medium rounded-md border transition-colors;
+    @apply border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700;
+  }
+
+  :global(.toggle-code-btn.active) {
+    @apply bg-blue-50 border-blue-300 text-blue-700 dark:bg-blue-900 dark:border-blue-600 dark:text-blue-200;
+  }
+
+  /* Demo Container */
+  :global(.example-demo) {
+    @apply space-y-4;
+  }
+
+  :global(.demo-container) {
+    @apply p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg;
+    @apply shadow-sm;
+  }
+
+  /* Code Container */
+  :global(.code-container) {
+    @apply border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden;
+  }
+
+  :global(.code-header) {
+    @apply flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700;
+  }
+
+  :global(.code-label) {
+    @apply text-sm font-medium text-gray-700 dark:text-gray-300;
+  }
+
+  :global(.copy-code-btn) {
+    @apply px-2 py-1 text-xs font-medium rounded border transition-colors;
+    @apply border-gray-300 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700;
+  }
+
+  :global(.code-block) {
+    @apply p-4 bg-gray-900 text-gray-100 overflow-x-auto text-sm;
+    @apply font-mono leading-relaxed;
+  }
+
+  /* Storybook Section */
+  :global(.storybook-section) {
+    @apply space-y-4;
+  }
+
+  :global(.storybook-section h2) {
+    @apply text-2xl font-semibold text-gray-900 dark:text-white;
+  }
+
+  :global(.storybook-description) {
+    @apply text-gray-600 dark:text-gray-300;
+  }
+
+  :global(.storybook-container) {
+    @apply border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden;
+    @apply h-96;
+  }
+
+  :global(.storybook-iframe) {
+    @apply w-full h-full border-0;
+  }
+
+  :global(.storybook-links) {
+    @apply flex justify-center;
+  }
+
+  :global(.storybook-link) {
+    @apply inline-flex items-center px-4 py-2 text-sm font-medium rounded-md;
+    @apply bg-blue-600 text-white hover:bg-blue-700 transition-colors;
+    @apply no-underline;
+  }
+
+  /* Props Section */
+  :global(.props-section) {
+    @apply space-y-4;
+  }
+
+  /* JSDoc Examples */
+  :global(.jsdoc-examples-section) {
+    @apply space-y-4;
+  }
+
+  :global(.jsdoc-examples-section h2) {
+    @apply text-2xl font-semibold text-gray-900 dark:text-white;
+  }
+
+  :global(.jsdoc-examples-description) {
+    @apply text-gray-600 dark:text-gray-300;
+  }
+
+  :global(.jsdoc-example) {
+    @apply space-y-2;
+  }
+
+  :global(.jsdoc-example h4) {
+    @apply text-lg font-medium text-gray-900 dark:text-white;
+  }
+
+  :global(.example-code) {
+    @apply p-4 bg-gray-900 text-gray-100 rounded-lg overflow-x-auto text-sm;
+    @apply font-mono;
+  }
+
+  /* Source Section */
+  :global(.source-section) {
+    @apply space-y-4 pt-6 border-t border-gray-200 dark:border-gray-700;
+  }
+
+  :global(.source-section h2) {
+    @apply text-2xl font-semibold text-gray-900 dark:text-white;
+  }
+
+  :global(.source-links) {
+    @apply flex flex-wrap gap-3;
+  }
+
+  :global(.source-link) {
+    @apply inline-flex items-center px-4 py-2 text-sm font-medium rounded-md;
+    @apply bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700;
+    @apply transition-colors no-underline;
+  }
+</style>

--- a/docs/src/components/showcase/ComponentShowcase.tsx
+++ b/docs/src/components/showcase/ComponentShowcase.tsx
@@ -1,0 +1,246 @@
+import React, {useState} from 'react'
+import {PropsTable, type PropDocumentation} from './PropsTable'
+
+/**
+ * Component documentation structure matching JSDoc extraction output
+ */
+export interface ComponentDocumentation {
+  /** Component name */
+  name: string
+  /** File path relative to packages/ui/src */
+  filePath: string
+  /** Component description from JSDoc */
+  description?: string
+  /** Component props interface documentation */
+  props?: PropDocumentation[]
+  /** Usage examples extracted from JSDoc */
+  examples?: string[]
+  /** Whether this is the default export */
+  isDefault: boolean
+}
+
+/**
+ * Configuration for a live component example
+ */
+export interface ExampleConfig {
+  /** Example title */
+  title: string
+  /** Description of what this example demonstrates */
+  description?: string
+  /** React component to render */
+  component: React.ReactNode
+  /** Source code to display */
+  code: string
+  /** Whether to show code by default */
+  showCode?: boolean
+}
+
+/**
+ * Props for the ComponentShowcase component
+ */
+export interface ComponentShowcaseProps {
+  /** Component documentation extracted from JSDoc */
+  documentation: ComponentDocumentation
+  /** Live examples to demonstrate the component */
+  examples: ExampleConfig[]
+  /** Optional Storybook story ID for iframe embed */
+  storybookId?: string
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Comprehensive component showcase with live examples, props table, and API documentation
+ *
+ * Combines interactive component demonstrations with comprehensive documentation
+ * extracted from JSDoc comments and TypeScript interfaces.
+ */
+export const ComponentShowcase: React.FC<ComponentShowcaseProps> = ({
+  documentation,
+  examples,
+  storybookId,
+  className = '',
+}) => {
+  const [activeExampleIndex, setActiveExampleIndex] = useState(0)
+  const [showCode, setShowCode] = useState(false)
+
+  const activeExample = examples[activeExampleIndex]
+
+  return (
+    <div className={`component-showcase ${className}`}>
+      {/* Header Section */}
+      <div className="showcase-header">
+        <h1 className="component-title">{documentation.name}</h1>
+        {documentation.description && <p className="component-description">{documentation.description}</p>}
+        <div className="component-meta">
+          <span className="file-path">📁 {documentation.filePath}</span>
+          {documentation.isDefault && <span className="default-export-badge">Default Export</span>}
+        </div>
+      </div>
+
+      {/* Live Examples Section */}
+      <section className="examples-section">
+        <div className="section-header">
+          <h2>Examples</h2>
+          {examples.length > 1 && (
+            <div className="example-tabs">
+              {examples.map((example, index) => (
+                <button
+                  key={index}
+                  className={`example-tab ${index === activeExampleIndex ? 'active' : ''}`}
+                  onClick={() => setActiveExampleIndex(index)}
+                >
+                  {example.title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {activeExample && (
+          <div className="example-content">
+            <div className="example-header">
+              <h3>{activeExample.title}</h3>
+              {activeExample.description && <p className="example-description">{activeExample.description}</p>}
+              <div className="example-controls">
+                <button
+                  className={`toggle-code-btn ${showCode ? 'active' : ''}`}
+                  onClick={() => setShowCode(!showCode)}
+                >
+                  {showCode ? '👁️ Hide Code' : '👁️ Show Code'}
+                </button>
+              </div>
+            </div>
+
+            <div className="example-demo">
+              <div className="demo-container">{activeExample.component}</div>
+
+              {showCode && (
+                <div className="code-container">
+                  <div className="code-header">
+                    <span className="code-label">React Code</span>
+                    <button className="copy-code-btn" onClick={() => navigator.clipboard.writeText(activeExample.code)}>
+                      📋 Copy
+                    </button>
+                  </div>
+                  <pre className="code-block">
+                    <code>{activeExample.code}</code>
+                  </pre>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Storybook Integration */}
+      {storybookId && (
+        <section className="storybook-section">
+          <h2>Interactive Playground</h2>
+          <p className="storybook-description">
+            Explore all variations and configurations in our interactive Storybook playground:
+          </p>
+          <div className="storybook-container">
+            <iframe
+              src={`/storybook/iframe.html?id=${storybookId}&viewMode=story`}
+              className="storybook-iframe"
+              title={`${documentation.name} Storybook`}
+              loading="lazy"
+            />
+          </div>
+          <div className="storybook-links">
+            <a
+              href={`/storybook/?path=/story/${storybookId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="storybook-link"
+            >
+              🚀 Open in Storybook
+            </a>
+          </div>
+        </section>
+      )}
+
+      {/* Props Documentation */}
+      {documentation.props && documentation.props.length > 0 && (
+        <section className="props-section">
+          <PropsTable props={documentation.props} title="Props API" />
+        </section>
+      )}
+
+      {/* JSDoc Examples */}
+      {documentation.examples && documentation.examples.length > 0 && (
+        <section className="jsdoc-examples-section">
+          <h2>Additional Examples</h2>
+          <p className="jsdoc-examples-description">Code examples extracted from JSDoc documentation:</p>
+          {documentation.examples.map((example, index) => (
+            <div key={index} className="jsdoc-example">
+              <h4>Example {index + 1}</h4>
+              <pre className="example-code">
+                <code>{example}</code>
+              </pre>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {/* Source Code Links */}
+      <section className="source-section">
+        <h2>Source Code</h2>
+        <div className="source-links">
+          <a
+            href={`https://github.com/marcusrbrown/sparkle/blob/main/packages/ui/src/${documentation.filePath}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="source-link"
+          >
+            📄 View Source on GitHub
+          </a>
+          <a
+            href={`https://github.com/marcusrbrown/sparkle/blob/main/packages/ui/src/${documentation.filePath.replace('.tsx', '.test.tsx')}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="source-link"
+          >
+            🧪 View Tests
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+/**
+ * Hook to load component documentation from the generated JSON file
+ */
+export const useComponentDocumentation = (componentName: string): ComponentDocumentation | null => {
+  const [documentation, setDocumentation] = React.useState<ComponentDocumentation | null>(null)
+
+  React.useEffect(() => {
+    // In a real implementation, this would fetch from the generated component-docs.json
+    // For now, we'll return null and let the parent component provide the data
+    // This hook structure allows for future async loading if needed
+    setDocumentation(null)
+  }, [componentName])
+
+  return documentation
+}
+
+/**
+ * Utility function to create an ExampleConfig
+ */
+export const createExample = (
+  title: string,
+  component: React.ReactNode,
+  code: string,
+  options: {
+    description?: string
+    showCode?: boolean
+  } = {},
+): ExampleConfig => ({
+  title,
+  component,
+  code,
+  description: options.description,
+  showCode: options.showCode ?? false,
+})

--- a/docs/src/components/showcase/PropsTable.astro
+++ b/docs/src/components/showcase/PropsTable.astro
@@ -1,0 +1,148 @@
+---
+export interface Props {
+  /** Component name to load props for */
+  componentName: string
+  /** Optional title override */
+  title?: string
+}
+
+const {componentName, title = 'Props'} = Astro.props
+
+// Load component documentation from generated JSON
+let props: any[] = []
+
+try {
+  const componentDocsModule = await import('../../generated/component-docs.json')
+  const allDocs = componentDocsModule.default as any[]
+  const componentDoc = allDocs.find(doc => doc.name === componentName)
+  props = componentDoc?.props || []
+} catch (error) {
+  console.warn(`Failed to load props for ${componentName}:`, error)
+}
+---
+
+{props.length > 0 ? (
+  <div class="props-table-container">
+    <h3 class="props-table-title">{title}</h3>
+    <div class="props-table-wrapper">
+      <table class="props-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.map((prop) => (
+            <tr>
+              <td class="prop-name">
+                <code>{prop.name}</code>
+              </td>
+              <td class="prop-type">
+                <code class="type-code">{prop.type}</code>
+              </td>
+              <td class="prop-required">
+                {prop.required ? (
+                  <span class="required-badge">Required</span>
+                ) : (
+                  <span class="optional-badge">Optional</span>
+                )}
+              </td>
+              <td class="prop-default">
+                {prop.defaultValue ? (
+                  <code class="default-code">{prop.defaultValue}</code>
+                ) : (
+                  <span class="no-default">—</span>
+                )}
+              </td>
+              <td class="prop-description">
+                {prop.description || <span class="no-description">—</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+) : (
+  <div class="props-table-empty">
+    <p class="text-gray-500 text-sm italic">No props documented for this component.</p>
+  </div>
+)}
+
+<style>
+  .props-table-container {
+    @apply space-y-4;
+  }
+
+  .props-table-title {
+    @apply text-xl font-semibold text-gray-900 dark:text-white;
+  }
+
+  .props-table-wrapper {
+    @apply overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg;
+  }
+
+  .props-table {
+    @apply w-full text-sm;
+  }
+
+  .props-table thead {
+    @apply bg-gray-50 dark:bg-gray-800;
+  }
+
+  .props-table th {
+    @apply px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider;
+  }
+
+  .props-table tbody {
+    @apply bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700;
+  }
+
+  .props-table td {
+    @apply px-6 py-4 whitespace-nowrap;
+  }
+
+  .prop-name code {
+    @apply font-mono text-sm font-medium text-blue-600 dark:text-blue-400;
+  }
+
+  .prop-type {
+    @apply max-w-xs;
+  }
+
+  .type-code {
+    @apply font-mono text-xs text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded;
+    @apply break-words;
+  }
+
+  .required-badge {
+    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
+    @apply bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200;
+  }
+
+  .optional-badge {
+    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
+    @apply bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200;
+  }
+
+  .default-code {
+    @apply font-mono text-xs text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900 px-2 py-1 rounded;
+  }
+
+  .no-default,
+  .no-description {
+    @apply text-gray-400 dark:text-gray-500 italic;
+  }
+
+  .prop-description {
+    @apply text-gray-600 dark:text-gray-300 max-w-md;
+  }
+
+  .props-table-empty {
+    @apply text-center py-8;
+  }
+</style>

--- a/docs/src/components/showcase/PropsTable.tsx
+++ b/docs/src/components/showcase/PropsTable.tsx
@@ -1,0 +1,130 @@
+import React from 'react'
+
+/**
+ * Interface for describing a component prop - matches the structure from JSDoc extraction
+ */
+export interface PropDocumentation {
+  /** Property name */
+  name: string
+  /** TypeScript type */
+  type: string
+  /** Whether the prop is required */
+  required: boolean
+  /** Default value if any */
+  defaultValue?: string
+  /** JSDoc description */
+  description?: string
+}
+
+/**
+ * Props for the PropsTable component
+ */
+export interface PropsTableProps {
+  /**
+   * Array of prop definitions to display
+   */
+  props: PropDocumentation[]
+  /**
+   * Optional title for the props table
+   */
+  title?: string
+  /**
+   * Additional CSS classes
+   */
+  className?: string
+}
+
+/**
+ * PropsTable component for displaying component prop documentation
+ *
+ * Renders a comprehensive table showing prop names, types, descriptions,
+ * required status, and default values for TypeScript component interfaces.
+ */
+export const PropsTable: React.FC<PropsTableProps> = ({props, title = 'Props', className = ''}) => {
+  if (!props || props.length === 0) {
+    return (
+      <div className={`props-table-empty ${className}`}>
+        <p className="text-gray-500 text-sm italic">No props documented for this component.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`props-table-container ${className}`}>
+      <h3 className="props-table-title">{title}</h3>
+      <div className="props-table-wrapper">
+        <table className="props-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Required</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {props.map(prop => (
+              <tr key={prop.name}>
+                <td className="prop-name">
+                  <code>{prop.name}</code>
+                </td>
+                <td className="prop-type">
+                  <code className="type-code">{prop.type}</code>
+                </td>
+                <td className="prop-required">
+                  {prop.required ? (
+                    <span className="required-badge">Required</span>
+                  ) : (
+                    <span className="optional-badge">Optional</span>
+                  )}
+                </td>
+                <td className="prop-default">
+                  {prop.defaultValue ? (
+                    <code className="default-code">{prop.defaultValue}</code>
+                  ) : (
+                    <span className="no-default">—</span>
+                  )}
+                </td>
+                <td className="prop-description">{prop.description || <span className="no-description">—</span>}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Utility function to create PropDocumentation from TypeScript interface
+ * This is a helper for manual prop definition creation
+ */
+export const createPropDefinition = (
+  name: string,
+  type: string,
+  options: {
+    description?: string
+    required?: boolean
+    defaultValue?: string
+  } = {},
+): PropDocumentation => ({
+  name,
+  type,
+  description: options.description,
+  required: options.required ?? false,
+  defaultValue: options.defaultValue,
+})
+
+/**
+ * Pre-defined common prop types for easy reuse
+ */
+export const CommonPropTypes = {
+  STRING: 'string',
+  NUMBER: 'number',
+  BOOLEAN: 'boolean',
+  FUNCTION: '() => void',
+  REACT_NODE: 'React.ReactNode',
+  CSS_CLASS: 'string',
+  HTML_ATTRIBUTES: 'HTMLAttributes<HTMLElement>',
+} as const

--- a/docs/src/content/docs/components/button.mdx
+++ b/docs/src/content/docs/components/button.mdx
@@ -1,0 +1,178 @@
+---
+title: 'Button Component'
+description: 'Interactive Button component showcase with live examples and API documentation'
+---
+
+import {Button} from '@sparkle/ui'
+import ComponentShowcase from '../../../components/showcase/ComponentShowcase.astro'
+import PropsTable from '../../../components/showcase/PropsTable.astro'
+
+<ComponentShowcase
+  componentName="Button"
+  examples={[]}
+  storybookId="components-button--primary"
+  className="button-showcase"
+/>
+
+## Live Examples
+
+### Basic Variants
+
+The four main button variants available in the design system:
+
+<div style="display: flex; gap: 1rem; flex-wrap: wrap; margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <Button variant="primary">Primary</Button>
+  <Button variant="secondary">Secondary</Button>
+  <Button variant="outline">Outline</Button>
+  <Button variant="ghost">Ghost</Button>
+</div>
+
+```jsx
+<Button variant="primary">Primary</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="outline">Outline</Button>
+<Button variant="ghost">Ghost</Button>
+```
+
+### Sizes
+
+Three sizes available: small, medium (default), and large:
+
+<div style="display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <Button size="sm">Small</Button>
+  <Button size="md">Medium</Button>
+  <Button size="lg">Large</Button>
+</div>
+
+```jsx
+<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="lg">Large</Button>
+```
+
+### Semantic Colors
+
+Semantic color variants for contextual actions:
+
+<div style="display: flex; gap: 1rem; flex-wrap: wrap; margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <Button semantic="default">Default</Button>
+  <Button semantic="success">Success</Button>
+  <Button semantic="warning">Warning</Button>
+  <Button semantic="error">Error</Button>
+</div>
+
+```jsx
+<Button semantic="default">Default</Button>
+<Button semantic="success">Success</Button>
+<Button semantic="warning">Warning</Button>
+<Button semantic="error">Error</Button>
+```
+
+### Interactive States
+
+Different interactive states including disabled:
+
+<div style="display: flex; gap: 1rem; flex-wrap: wrap; margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <Button>Normal</Button>
+  <Button disabled>Disabled</Button>
+</div>
+
+```jsx
+<Button>Normal</Button>
+<Button disabled>Disabled</Button>
+<Button onClick={() => alert('Clicked!')}>Clickable</Button>
+```
+
+### Advanced Combinations
+
+Complex combinations of variants, sizes, and semantic colors:
+
+<div style="margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem;">
+    <Button variant="primary" size="lg" semantic="success">
+      ✅ Save Changes
+    </Button>
+    <Button variant="outline" size="lg" semantic="error">
+      ❌ Cancel
+    </Button>
+  </div>
+  <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+    <Button variant="ghost" size="sm">
+      📝 Edit
+    </Button>
+    <Button variant="ghost" size="sm" semantic="error">
+      🗑️ Delete
+    </Button>
+  </div>
+</div>
+
+```jsx
+<Button variant="primary" size="lg" semantic="success">
+  ✅ Save Changes
+</Button>
+<Button variant="outline" size="lg" semantic="error">
+  ❌ Cancel
+</Button>
+<Button variant="ghost" size="sm">
+  📝 Edit
+</Button>
+<Button variant="ghost" size="sm" semantic="error">
+  🗑️ Delete
+</Button>
+```
+
+## API Reference
+
+<PropsTable componentName="Button" />
+
+## Storybook Playground
+
+Explore all Button variations in our interactive Storybook:
+
+<div style="border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden; height: 400px; margin: 1rem 0;">
+  <iframe
+    src="/storybook/iframe.html?id=components-button--primary&viewMode=story"
+    style="width: 100%; height: 100%; border: 0;"
+    title="Button Storybook"
+    loading="lazy"
+  />
+</div>
+
+<div style="text-align: center; margin: 1rem 0;">
+  <a
+    href="/storybook/?path=/story/components-button--primary"
+    target="_blank"
+    rel="noopener noreferrer"
+    style="display: inline-flex; align-items: center; padding: 0.5rem 1rem; background: #3b82f6; color: white; text-decoration: none; border-radius: 0.375rem;"
+  >
+    🚀 Open in Storybook
+  </a>
+</div>
+
+## Usage Guidelines
+
+### When to Use
+
+- **Primary actions**: Use the primary variant for the main action on a page
+- **Secondary actions**: Use secondary or outline variants for supporting actions
+- **Destructive actions**: Use the error semantic variant for delete/remove actions
+- **Success confirmations**: Use the success semantic variant for save/confirm actions
+
+### Accessibility
+
+The Button component includes:
+
+- Proper ARIA attributes for screen readers
+- Keyboard navigation support (Tab, Enter, Space)
+- Focus indicators that meet WCAG contrast requirements
+- Disabled state handling that prevents interaction
+
+### Theme Integration
+
+Buttons automatically adapt to light and dark themes using CSS custom properties from `@sparkle/theme`. The semantic color variants maintain proper contrast ratios across all theme modes.
+
+## Related Components
+
+- **IconButton**: For icon-only actions
+- **ButtonGroup**: For related button collections
+- **ToggleButton**: For on/off state toggles

--- a/docs/src/content/docs/components/form.mdx
+++ b/docs/src/content/docs/components/form.mdx
@@ -1,0 +1,161 @@
+---
+title: 'Form Component'
+description: 'Interactive Form component showcase with live examples and API documentation'
+---
+
+import {Form} from '@sparkle/ui'
+import PropsTable from '../../../components/showcase/PropsTable.astro'
+
+## Live Examples
+
+### Basic Form
+
+A simple form with accessible validation and submission handling:
+
+<div style="margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <Form onSubmit={(e) => { e.preventDefault(); alert('Form submitted!'); }}>
+    <div style="margin-bottom: 1rem;">
+      <label htmlFor="email" style="display: block; margin-bottom: 0.5rem; font-weight: 500;">
+        Email
+      </label>
+      <input
+        type="email"
+        id="email"
+        name="email"
+        required
+        style="width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem;"
+      />
+    </div>
+    <div style="margin-bottom: 1rem;">
+      <label htmlFor="message" style="display: block; margin-bottom: 0.5rem; font-weight: 500;">
+        Message
+      </label>
+      <textarea
+        id="message"
+        name="message"
+        rows="3"
+        style="width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem;"
+      />
+    </div>
+    <button
+      type="submit"
+      style="background: #3b82f6; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; cursor: pointer;"
+    >
+      Submit
+    </button>
+  </Form>
+</div>
+
+```jsx
+<Form onSubmit={(e) => { e.preventDefault(); console.log('Form submitted!'); }}>
+  <div>
+    <label htmlFor="email">Email</label>
+    <input type="email" id="email" name="email" required />
+  </div>
+  <div>
+    <label htmlFor="message">Message</label>
+    <textarea id="message" name="message" rows="3" />
+  </div>
+  <button type="submit">Submit</button>
+</Form>
+```
+
+### Form with Clear on Submit
+
+A form that clears fields after successful submission:
+
+<div style="margin: 1rem 0; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem;">
+  <Form clearOnSubmit={true} onSubmit={(e) => { e.preventDefault(); alert('Form submitted and cleared!'); }}>
+    <div style="margin-bottom: 1rem;">
+      <label htmlFor="name" style="display: block; margin-bottom: 0.5rem; font-weight: 500;">
+        Name
+      </label>
+      <input
+        type="text"
+        id="name"
+        name="name"
+        style="width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem;"
+      />
+    </div>
+    <button
+      type="submit"
+      style="background: #10b981; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; cursor: pointer;"
+    >
+      Submit & Clear
+    </button>
+  </Form>
+</div>
+
+```jsx
+<Form clearOnSubmit={true} onSubmit={handleSubmit}>
+  <div>
+    <label htmlFor="name">Name</label>
+    <input type="text" id="name" name="name" />
+  </div>
+  <button type="submit">Submit & Clear</button>
+</Form>
+```
+
+## API Reference
+
+<PropsTable componentName="Form" />
+
+## Storybook Playground
+
+Explore all Form variations in our interactive Storybook:
+
+<div style="border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden; height: 400px; margin: 1rem 0;">
+  <iframe
+    src="/storybook/iframe.html?id=components-form--default&viewMode=story"
+    style="width: 100%; height: 100%; border: 0;"
+    title="Form Storybook"
+    loading="lazy"
+  />
+</div>
+
+<div style="text-align: center; margin: 1rem 0;">
+  <a
+    href="/storybook/?path=/story/components-form--default"
+    target="_blank"
+    rel="noopener noreferrer"
+    style="display: inline-flex; align-items: center; padding: 0.5rem 1rem; background: #3b82f6; color: white; text-decoration: none; border-radius: 0.375rem;"
+  >
+    🚀 Open in Storybook
+  </a>
+</div>
+
+## Usage Guidelines
+
+### When to Use
+
+- **Data Collection**: Use for gathering user input and data submission
+- **Settings**: Use for configuration and preference forms
+- **Contact**: Use for contact and feedback forms
+- **Registration**: Use for user registration and onboarding flows
+
+### Accessibility
+
+The Form component includes:
+
+- Proper form structure and semantic HTML
+- Label association with form controls
+- Error handling and validation feedback
+- Keyboard navigation support
+- Screen reader compatibility
+
+### Form Validation
+
+The Form component supports:
+
+- HTML5 validation attributes (`required`, `pattern`, etc.)
+- Custom validation via JavaScript
+- Real-time validation feedback
+- Accessible error messaging
+
+## Related Components
+
+- **Input**: For text input fields
+- **TextArea**: For multi-line text input
+- **Select**: For dropdown selections
+- **Checkbox**: For boolean choices
+- **RadioGroup**: For single selection from multiple options


### PR DESCRIPTION
- Create documentation for the Button component with live examples and API reference.
- Add interactive examples showcasing different button variants, sizes, and states.
- Develop Form component documentation including validation and submission handling examples.
- Integrate PropsTable for both Button and Form components to display prop details.

Relates to TASK-022 on #873.