### PR TITLE
refactor: replace console logging with consola

### DIFF
--- a/docs/scripts/extract-jsdoc.ts
+++ b/docs/scripts/extract-jsdoc.ts
@@ -2,6 +2,7 @@ import {existsSync, mkdirSync, writeFileSync} from 'node:fs'
 import {dirname, join, relative} from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
+import {consola} from 'consola'
 
 import {parse as parseJSDoc, type Annotation} from 'doctrine'
 import {Project, SyntaxKind, type FunctionDeclaration, type VariableDeclaration} from 'ts-morph'
@@ -67,7 +68,7 @@ export class JSDocExtractor {
    * Extracts documentation from all components in the UI package
    */
   async extractAll(): Promise<ComponentDocumentation[]> {
-    console.log('🔍 Extracting JSDoc documentation from @sparkle/ui components...')
+    consola.info('🔍 Extracting JSDoc documentation from @sparkle/ui components...')
 
     const componentFiles = this.project.getSourceFiles().filter(file => {
       const filePath = file.getFilePath()
@@ -92,7 +93,7 @@ export class JSDocExtractor {
       }
     }
 
-    console.log(`✅ Extracted documentation for ${documentation.length} components`)
+    consola.success(`✅ Extracted documentation for ${documentation.length} components`)
     return documentation
   }
 
@@ -315,7 +316,7 @@ export class JSDocExtractor {
     }
 
     writeFileSync(outputFile, JSON.stringify(documentation, null, 2))
-    console.log(`📝 Saved component documentation to ${outputFile}`)
+    consola.info(`📝 Saved component documentation to ${outputFile}`)
   }
 }
 
@@ -326,9 +327,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   try {
     const documentation = await extractor.extractAll()
     await extractor.saveDocumentation(documentation)
-    console.log('🎉 JSDoc extraction completed successfully!')
+    consola.success('🎉 JSDoc extraction completed successfully!')
   } catch (error) {
-    console.error('❌ JSDoc extraction failed:', error)
+    consola.error('❌ JSDoc extraction failed:', error)
     process.exit(1)
   }
 }

--- a/scripts/enhanced-error-reporter.ts
+++ b/scripts/enhanced-error-reporter.ts
@@ -3,6 +3,9 @@
 /**
  * Enhanced Error Reporter for Sparkle Monorepo
  * Provides improved error formatting and reporting for TypeScript errors, build failures, and cross-package dependency issues
+ *
+ * Refactored to use functional programming patterns instead of ES6 classes,
+ * following project coding standards.
  */
 
 import type {Buffer} from 'node:buffer'
@@ -10,6 +13,7 @@ import {spawn} from 'node:child_process'
 import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs'
 import {relative, resolve} from 'node:path'
 import process from 'node:process'
+import {consola} from 'consola'
 
 // ANSI color codes for enhanced output formatting
 const colors = {
@@ -56,451 +60,494 @@ interface PackageInfo {
 }
 
 /**
- * Enhanced Error Reporter class for processing and formatting build errors
+ * Enhanced error reporter state for tracking packages and error counts.
  */
-export class EnhancedErrorReporter {
-  private packages: Map<string, PackageInfo> = new Map()
-  private errorCount = 0
-  private warningCount = 0
+interface ErrorReporterState {
+  packages: Map<string, PackageInfo>
+  errorCount: number
+  warningCount: number
+}
 
-  constructor() {
-    this.loadPackageInfo()
+/**
+ * Creates initial state for error reporter.
+ */
+function createErrorReporterState(): ErrorReporterState {
+  const state: ErrorReporterState = {
+    packages: new Map(),
+    errorCount: 0,
+    warningCount: 0,
   }
 
-  /**
-   * Load package information for cross-package error analysis
-   */
-  private loadPackageInfo(): void {
-    const rootDir = process.cwd()
-    const packagesDir = resolve(rootDir, 'packages')
-    const appsDir = resolve(rootDir, 'apps')
+  loadPackageInfo(state)
+  return state
+}
 
-    // Load packages from packages/ directory
-    if (existsSync(packagesDir)) {
-      this.loadPackagesFromDir(packagesDir)
-    }
+/**
+ * Load package information for cross-package error analysis.
+ */
+function loadPackageInfo(state: ErrorReporterState): void {
+  const rootDir = process.cwd()
+  const packagesDir = resolve(rootDir, 'packages')
+  const appsDir = resolve(rootDir, 'apps')
 
-    // Load packages from apps/ directory
-    if (existsSync(appsDir)) {
-      this.loadPackagesFromDir(appsDir)
-    }
+  // Load packages from packages/ directory
+  if (existsSync(packagesDir)) {
+    loadPackagesFromDir(state, packagesDir)
   }
 
-  /**
-   * Load package information from a directory
-   */
-  private loadPackagesFromDir(dir: string): void {
-    try {
-      const entries = readdirSync(dir)
-
-      for (const entry of entries) {
-        const packagePath = resolve(dir, entry)
-        const packageJsonPath = resolve(packagePath, 'package.json')
-
-        if (statSync(packagePath).isDirectory() && existsSync(packageJsonPath)) {
-          try {
-            const packageJsonContent = readFileSync(packageJsonPath, 'utf-8')
-            const packageJson = JSON.parse(packageJsonContent)
-
-            const dependencies = [
-              ...Object.keys(packageJson.dependencies || {}),
-              ...Object.keys(packageJson.devDependencies || {}),
-              ...Object.keys(packageJson.peerDependencies || {}),
-            ]
-
-            this.packages.set(packageJson.name || entry, {
-              name: packageJson.name || entry,
-              path: packagePath,
-              dependencies,
-            })
-          } catch {
-            // Skip invalid package.json files
-          }
-        }
-      }
-    } catch {
-      // Skip directories that can't be read
-    }
-  }
-
-  /**
-   * Parse error context from error output
-   */
-  private parseErrorContext(errorLine: string, _previousLines: string[] = []): ErrorContext | null {
-    // TypeScript error parsing - more specific regex patterns
-    const tsMatch = errorLine.match(/^(.+)\((\d+),(\d+)\):\s+(error|warning|info)\s+TS(\d+):\s(.*)$/i)
-    if (tsMatch) {
-      const [, file, line, column, severity, code, message] = tsMatch
-      return {
-        file: file.trim(),
-        line: Number.parseInt(line, 10),
-        column: Number.parseInt(column, 10),
-        severity: severity.toLowerCase() as 'error' | 'warning' | 'info',
-        category: 'typescript',
-        code: `TS${code}`,
-        message: message.trim(),
-        package: this.getPackageFromFile(file),
-        suggestion: this.generateSuggestion(code, message),
-      }
-    }
-
-    // Generic error parsing with file reference - more specific regex
-    const fileMatch = errorLine.match(/^([^:]+):(\d+):(\d+):\s+(error|warning|info):\s(.*)$/i)
-    if (fileMatch) {
-      const [, file, line, column, severity, message] = fileMatch
-      return {
-        file: file.trim(),
-        line: Number.parseInt(line, 10),
-        column: Number.parseInt(column, 10),
-        severity: severity.toLowerCase() as 'error' | 'warning' | 'info',
-        category: this.categorizeError(message),
-        message: message.trim(),
-        package: this.getPackageFromFile(file),
-        suggestion: this.generateSuggestion(undefined, message),
-      }
-    }
-
-    // Build error parsing
-    if (ERROR_PATTERNS.build.test(errorLine)) {
-      return {
-        severity: 'error',
-        category: 'build',
-        message: errorLine.trim(),
-        suggestion: 'Check build configuration and dependencies',
-      }
-    }
-
-    // Dependency error parsing
-    if (ERROR_PATTERNS.dependency.test(errorLine)) {
-      return {
-        severity: 'error',
-        category: 'dependency',
-        message: errorLine.trim(),
-        suggestion: this.generateDependencySuggestion(errorLine),
-      }
-    }
-
-    return null
-  }
-
-  /**
-   * Categorize error based on message content
-   */
-  private categorizeError(message: string): keyof typeof ERROR_PATTERNS {
-    if (ERROR_PATTERNS.importError.test(message)) return 'importError'
-    if (ERROR_PATTERNS.syntaxError.test(message)) return 'syntaxError'
-    if (ERROR_PATTERNS.typeError.test(message)) return 'typeError'
-    if (ERROR_PATTERNS.dependency.test(message)) return 'dependency'
-    return 'typescript'
-  }
-
-  /**
-   * Get package name from file path
-   */
-  private getPackageFromFile(filePath: string): string | undefined {
-    const normalizedPath = resolve(filePath)
-    for (const [name, info] of this.packages) {
-      if (normalizedPath.startsWith(info.path)) {
-        return name
-      }
-    }
-    return undefined
-  }
-
-  /**
-   * Generate helpful suggestions based on error code and message
-   */
-  private generateSuggestion(code?: string, message?: string, _file?: string): string | undefined {
-    if (!code && !message) return undefined
-
-    // TypeScript specific suggestions
-    if (code) {
-      switch (code) {
-        case 'TS2307':
-          return 'Check if the module is installed and properly exported. For internal packages, ensure workspace:* protocol is used.'
-        case 'TS2345':
-          return 'Check argument types and ensure they match the expected parameter types.'
-        case 'TS2339':
-          return 'Verify that the property exists on the type. Check for typos or missing imports.'
-        case 'TS2322':
-          return 'Check type compatibility. You may need type assertion or interface adjustment.'
-        case 'TS2554':
-          return 'Check function call arguments. You may be missing required parameters.'
-        case 'TS2531':
-          return 'Add null check or use optional chaining (?.) to handle potential null/undefined values.'
-        default:
-          break
-      }
-    }
-
-    // Message-based suggestions
-    if (message) {
-      if (message.includes('Cannot resolve module') || message.includes('Module not found')) {
-        return this.generateDependencySuggestion(message)
-      }
-      if (message.includes('Property') && message.includes('does not exist')) {
-        return 'Check property name spelling and ensure the type definition includes this property.'
-      }
-      if (message.includes('not assignable to type')) {
-        return 'Check type compatibility. Consider using type assertion or updating type definitions.'
-      }
-    }
-
-    return undefined
-  }
-
-  /**
-   * Generate dependency-specific suggestions
-   */
-  private generateDependencySuggestion(message: string): string {
-    if (message.includes('@sparkle/')) {
-      return 'Internal package dependency issue. Check that the package is built and uses workspace:* protocol.'
-    }
-    return 'Check if the dependency is installed with "pnpm install" and properly configured.'
-  }
-
-  /**
-   * Format TypeScript errors with enhanced context
-   */
-  private formatTypeScriptError(context: ErrorContext): void {
-    const icon = context.severity === 'error' ? '🚨' : context.severity === 'warning' ? '⚠️' : 'ℹ️'
-    const color =
-      context.severity === 'error' ? colors.red : context.severity === 'warning' ? colors.yellow : colors.blue
-
-    console.error(`${color}${colors.bold}${icon} TypeScript ${context.severity.toUpperCase()}${colors.reset}`)
-
-    if (context.file) {
-      const relativePath = relative(process.cwd(), context.file)
-      console.error(`${colors.cyan}📁 File:${colors.reset} ${relativePath}:${context.line}:${context.column}`)
-    }
-
-    if (context.package) {
-      console.error(`${colors.magenta}📦 Package:${colors.reset} ${context.package}`)
-    }
-
-    if (context.code) {
-      console.error(`${colors.yellow}🔢 Code:${colors.reset} ${context.code}`)
-    }
-
-    console.error(`${colors.white}💬 Message:${colors.reset} ${context.message}`)
-
-    if (context.suggestion) {
-      console.error(`${colors.green}💡 Suggestion:${colors.reset} ${context.suggestion}`)
-    }
-
-    console.error('') // Empty line for readability
-  }
-
-  /**
-   * Format build errors with enhanced context
-   */
-  private formatBuildError(context: ErrorContext): void {
-    console.error(`${colors.red}${colors.bold}🔥 BUILD ERROR${colors.reset}`)
-
-    if (context.package) {
-      console.error(`${colors.magenta}📦 Package:${colors.reset} ${context.package}`)
-    }
-
-    console.error(`${colors.white}💬 Message:${colors.reset} ${context.message}`)
-
-    if (context.suggestion) {
-      console.error(`${colors.green}💡 Suggestion:${colors.reset} ${context.suggestion}`)
-    }
-
-    console.error('') // Empty line for readability
-  }
-
-  /**
-   * Format dependency errors with cross-package context
-   */
-  private formatDependencyError(context: ErrorContext): void {
-    console.error(`${colors.yellow}${colors.bold}🔗 DEPENDENCY ERROR${colors.reset}`)
-
-    if (context.package) {
-      console.error(`${colors.magenta}📦 Package:${colors.reset} ${context.package}`)
-
-      // Show package dependencies for context
-      const packageInfo = this.packages.get(context.package)
-      if (packageInfo) {
-        const sparkledeps = packageInfo.dependencies.filter(dep => dep.startsWith('@sparkle/'))
-        if (sparkledeps.length > 0) {
-          console.error(`${colors.cyan}🔗 Internal Dependencies:${colors.reset} ${sparkledeps.join(', ')}`)
-        }
-      }
-    }
-
-    console.error(`${colors.white}💬 Message:${colors.reset} ${context.message}`)
-
-    if (context.suggestion) {
-      console.error(`${colors.green}💡 Suggestion:${colors.reset} ${context.suggestion}`)
-    }
-
-    console.error('') // Empty line for readability
-  }
-
-  /**
-   * Process and format errors from command output
-   */
-  private processErrorLine(line: string, previousLines: string[] = []): void {
-    const context = this.parseErrorContext(line, previousLines)
-    if (!context) return
-
-    // Update counters
-    if (context.severity === 'error') {
-      this.errorCount++
-    } else if (context.severity === 'warning') {
-      this.warningCount++
-    }
-
-    // Format based on error category
-    switch (context.category) {
-      case 'typescript':
-      case 'importError':
-      case 'syntaxError':
-      case 'typeError':
-        this.formatTypeScriptError(context)
-        break
-      case 'build':
-        this.formatBuildError(context)
-        break
-      case 'dependency':
-        this.formatDependencyError(context)
-        break
-      default:
-        // Fallback to basic formatting
-        console.error(line)
-        break
-    }
-  }
-
-  /**
-   * Run command with enhanced error reporting
-   */
-  runWithEnhancedErrors(command: string, args: string[] = [], options: {cwd?: string} = {}): Promise<number> {
-    return new Promise(resolve => {
-      const childProcess = spawn(command, args, {
-        stdio: ['inherit', 'pipe', 'pipe'],
-        cwd: options.cwd || process.cwd(),
-        shell: true,
-      })
-
-      const recentLines: string[] = []
-
-      // Process stdout
-      childProcess.stdout?.on('data', (data: Buffer) => {
-        const output = data.toString()
-
-        // Pass through normal output but look for errors
-        const lines = output.split('\n')
-        for (const line of lines) {
-          if (line.trim()) {
-            console.log(line)
-            this.processErrorLine(line, recentLines)
-            recentLines.push(line)
-            if (recentLines.length > 5) recentLines.shift()
-          }
-        }
-      })
-
-      // Process stderr with enhanced formatting
-      childProcess.stderr?.on('data', (data: Buffer) => {
-        const output = data.toString()
-
-        const lines = output.split('\n')
-        for (const line of lines) {
-          if (line.trim()) {
-            this.processErrorLine(line, recentLines)
-            recentLines.push(line)
-            if (recentLines.length > 5) recentLines.shift()
-          }
-        }
-      })
-
-      childProcess.on('close', (code: number | null) => {
-        const exitCode = code || 0
-
-        // Print summary if there were errors
-        if (this.errorCount > 0 || this.warningCount > 0) {
-          console.error('')
-          console.error(`${colors.bold}📊 Error Summary${colors.reset}`)
-          if (this.errorCount > 0) {
-            console.error(`${colors.red}❌ Errors: ${this.errorCount}${colors.reset}`)
-          }
-          if (this.warningCount > 0) {
-            console.error(`${colors.yellow}⚠️ Warnings: ${this.warningCount}${colors.reset}`)
-          }
-          console.error('')
-
-          if (this.errorCount > 0) {
-            console.error(`${colors.bold}🔧 Next Steps:${colors.reset}`)
-            console.error(`${colors.cyan}• Review the errors above and follow the suggestions${colors.reset}`)
-            console.error(
-              `${colors.cyan}• Run ${colors.bold}pnpm check${colors.reset}${colors.cyan} for comprehensive validation${colors.reset}`,
-            )
-            console.error(
-              `${colors.cyan}• Run ${colors.bold}pnpm health-check${colors.reset}${colors.cyan} to verify environment setup${colors.reset}`,
-            )
-            console.error('')
-          }
-        }
-
-        resolve(exitCode)
-      })
-
-      childProcess.on('error', (error: Error) => {
-        console.error(`${colors.red}${colors.bold}🚨 Process Error:${colors.reset} ${error.message}`)
-        resolve(1)
-      })
-    })
-  }
-
-  /**
-   * Reset error counters
-   */
-  reset(): void {
-    this.errorCount = 0
-    this.warningCount = 0
-  }
-
-  /**
-   * Get current error and warning counts
-   */
-  getCounts(): {errors: number; warnings: number} {
-    return {errors: this.errorCount, warnings: this.warningCount}
+  // Load packages from apps/ directory
+  if (existsSync(appsDir)) {
+    loadPackagesFromDir(state, appsDir)
   }
 }
 
 /**
- * CLI interface for enhanced error reporting
+ * Load package information from a directory.
+ */
+function loadPackagesFromDir(state: ErrorReporterState, dir: string): void {
+  try {
+    const entries = readdirSync(dir)
+
+    for (const entry of entries) {
+      const packagePath = resolve(dir, entry)
+      const packageJsonPath = resolve(packagePath, 'package.json')
+
+      if (statSync(packagePath).isDirectory() && existsSync(packageJsonPath)) {
+        try {
+          const packageJsonContent = readFileSync(packageJsonPath, 'utf-8')
+          const packageJson = JSON.parse(packageJsonContent)
+
+          const dependencies = [
+            ...Object.keys(packageJson.dependencies || {}),
+            ...Object.keys(packageJson.devDependencies || {}),
+            ...Object.keys(packageJson.peerDependencies || {}),
+          ]
+
+          state.packages.set(packageJson.name || entry, {
+            name: packageJson.name || entry,
+            path: packagePath,
+            dependencies,
+          })
+        } catch {
+          // Skip invalid package.json files
+        }
+      }
+    }
+  } catch {
+    // Skip directories that can't be read
+  }
+}
+
+/**
+ * Parse error context from error output.
+ */
+function parseErrorContext(
+  state: ErrorReporterState,
+  errorLine: string,
+  _previousLines: string[] = [],
+): ErrorContext | null {
+  // TypeScript error parsing - more specific regex patterns
+  const tsMatch = errorLine.match(/^(.+)\((\d+),(\d+)\):\s+(error|warning|info)\s+TS(\d+):\s(.*)$/i)
+  if (tsMatch) {
+    const [, file, line, column, severity, code, message] = tsMatch
+    return {
+      file: file.trim(),
+      line: Number.parseInt(line, 10),
+      column: Number.parseInt(column, 10),
+      severity: severity.toLowerCase() as 'error' | 'warning' | 'info',
+      category: 'typescript',
+      code: `TS${code}`,
+      message: message.trim(),
+      package: getPackageFromFile(state, file),
+      suggestion: generateSuggestion(code, message),
+    }
+  }
+
+  // Generic error parsing with file reference - more specific regex
+  const fileMatch = errorLine.match(/^([^:]+):(\d+):(\d+):\s+(error|warning|info):\s(.*)$/i)
+  if (fileMatch) {
+    const [, file, line, column, severity, message] = fileMatch
+    return {
+      file: file.trim(),
+      line: Number.parseInt(line, 10),
+      column: Number.parseInt(column, 10),
+      severity: severity.toLowerCase() as 'error' | 'warning' | 'info',
+      category: categorizeError(message),
+      message: message.trim(),
+      package: getPackageFromFile(state, file),
+      suggestion: generateSuggestion(undefined, message),
+    }
+  }
+
+  // Build error parsing
+  if (ERROR_PATTERNS.build.test(errorLine)) {
+    return {
+      severity: 'error',
+      category: 'build',
+      message: errorLine.trim(),
+      suggestion: 'Check build configuration and dependencies',
+    }
+  }
+
+  // Dependency error parsing
+  if (ERROR_PATTERNS.dependency.test(errorLine)) {
+    return {
+      severity: 'error',
+      category: 'dependency',
+      message: errorLine.trim(),
+      suggestion: generateDependencySuggestion(errorLine),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Categorize error based on message content.
+ */
+function categorizeError(message: string): keyof typeof ERROR_PATTERNS {
+  if (ERROR_PATTERNS.importError.test(message)) return 'importError'
+  if (ERROR_PATTERNS.syntaxError.test(message)) return 'syntaxError'
+  if (ERROR_PATTERNS.typeError.test(message)) return 'typeError'
+  if (ERROR_PATTERNS.dependency.test(message)) return 'dependency'
+  return 'typescript'
+}
+
+/**
+ * Get package name from file path.
+ */
+function getPackageFromFile(state: ErrorReporterState, filePath: string): string | undefined {
+  const normalizedPath = resolve(filePath)
+  for (const [name, info] of state.packages) {
+    if (normalizedPath.startsWith(info.path)) {
+      return name
+    }
+  }
+  return undefined
+}
+
+/**
+ * Generate helpful suggestions based on error code and message.
+ */
+function generateSuggestion(code?: string, message?: string, _file?: string): string | undefined {
+  if (!code && !message) return undefined
+
+  // TypeScript specific suggestions
+  if (code) {
+    switch (code) {
+      case 'TS2307':
+        return 'Check if the module is installed and properly exported. For internal packages, ensure workspace:* protocol is used.'
+      case 'TS2345':
+        return 'Check argument types and ensure they match the expected parameter types.'
+      case 'TS2339':
+        return 'Verify that the property exists on the type. Check for typos or missing imports.'
+      case 'TS2322':
+        return 'Check type compatibility. You may need type assertion or interface adjustment.'
+      case 'TS2554':
+        return 'Check function call arguments. You may be missing required parameters.'
+      case 'TS2531':
+        return 'Add null check or use optional chaining (?.) to handle potential null/undefined values.'
+      default:
+        break
+    }
+  }
+
+  // Message-based suggestions
+  if (message) {
+    if (message.includes('Cannot resolve module') || message.includes('Module not found')) {
+      return generateDependencySuggestion(message)
+    }
+    if (message.includes('Property') && message.includes('does not exist')) {
+      return 'Check property name spelling and ensure the type definition includes this property.'
+    }
+    if (message.includes('not assignable to type')) {
+      return 'Check type compatibility. Consider using type assertion or updating type definitions.'
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Generate dependency-specific suggestions.
+ */
+function generateDependencySuggestion(message: string): string {
+  if (message.includes('@sparkle/')) {
+    return 'Internal package dependency issue. Check that the package is built and uses workspace:* protocol.'
+  }
+  return 'Check if the dependency is installed with "pnpm install" and properly configured.'
+}
+
+/**
+ * Format TypeScript errors with enhanced context.
+ */
+function formatTypeScriptError(context: ErrorContext): void {
+  const icon = context.severity === 'error' ? '🚨' : context.severity === 'warning' ? '⚠️' : 'ℹ️'
+  const color = context.severity === 'error' ? colors.red : context.severity === 'warning' ? colors.yellow : colors.blue
+
+  consola.error(`${color}${colors.bold}${icon} TypeScript ${context.severity.toUpperCase()}${colors.reset}`)
+
+  if (context.file) {
+    const relativePath = relative(process.cwd(), context.file)
+    consola.error(`${colors.cyan}📁 File:${colors.reset} ${relativePath}:${context.line}:${context.column}`)
+  }
+
+  if (context.package) {
+    consola.error(`${colors.magenta}📦 Package:${colors.reset} ${context.package}`)
+  }
+
+  if (context.code) {
+    consola.error(`${colors.yellow}🔢 Code:${colors.reset} ${context.code}`)
+  }
+
+  consola.error(`${colors.white}💬 Message:${colors.reset} ${context.message}`)
+
+  if (context.suggestion) {
+    consola.error(`${colors.green}💡 Suggestion:${colors.reset} ${context.suggestion}`)
+  }
+
+  consola.error('') // Empty line for readability
+}
+
+/**
+ * Format build errors with enhanced context.
+ */
+function formatBuildError(context: ErrorContext): void {
+  consola.error(`${colors.red}${colors.bold}🔥 BUILD ERROR${colors.reset}`)
+
+  if (context.package) {
+    consola.error(`${colors.magenta}📦 Package:${colors.reset} ${context.package}`)
+  }
+
+  consola.error(`${colors.white}💬 Message:${colors.reset} ${context.message}`)
+
+  if (context.suggestion) {
+    consola.error(`${colors.green}💡 Suggestion:${colors.reset} ${context.suggestion}`)
+  }
+
+  consola.error('') // Empty line for readability
+}
+
+/**
+ * Format dependency errors with cross-package context.
+ */
+function formatDependencyError(state: ErrorReporterState, context: ErrorContext): void {
+  consola.error(`${colors.yellow}${colors.bold}🔗 DEPENDENCY ERROR${colors.reset}`)
+
+  if (context.package) {
+    consola.error(`${colors.magenta}📦 Package:${colors.reset} ${context.package}`)
+
+    // Show package dependencies for context
+    const packageInfo = state.packages.get(context.package)
+    if (packageInfo) {
+      const sparkledeps = packageInfo.dependencies.filter(dep => dep.startsWith('@sparkle/'))
+      if (sparkledeps.length > 0) {
+        consola.error(`${colors.cyan}🔗 Internal Dependencies:${colors.reset} ${sparkledeps.join(', ')}`)
+      }
+    }
+  }
+
+  consola.error(`${colors.white}💬 Message:${colors.reset} ${context.message}`)
+
+  if (context.suggestion) {
+    consola.error(`${colors.green}💡 Suggestion:${colors.reset} ${context.suggestion}`)
+  }
+
+  consola.error('') // Empty line for readability
+}
+
+/**
+ * Process and format errors from command output.
+ */
+function processErrorLine(state: ErrorReporterState, line: string, previousLines: string[] = []): void {
+  const context = parseErrorContext(state, line, previousLines)
+  if (!context) return
+
+  // Update counters
+  if (context.severity === 'error') {
+    state.errorCount++
+  } else if (context.severity === 'warning') {
+    state.warningCount++
+  }
+
+  // Format based on error category
+  switch (context.category) {
+    case 'typescript':
+    case 'importError':
+    case 'syntaxError':
+    case 'typeError':
+      formatTypeScriptError(context)
+      break
+    case 'build':
+      formatBuildError(context)
+      break
+    case 'dependency':
+      formatDependencyError(state, context)
+      break
+    default:
+      // Fallback to basic formatting
+      consola.error(line)
+      break
+  }
+}
+
+/**
+ * Run command with enhanced error reporting.
+ */
+function runWithEnhancedErrors(
+  state: ErrorReporterState,
+  command: string,
+  args: string[] = [],
+  options: {cwd?: string} = {},
+): Promise<number> {
+  return new Promise(resolve => {
+    const childProcess = spawn(command, args, {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      cwd: options.cwd || process.cwd(),
+      shell: true,
+    })
+
+    const recentLines: string[] = []
+
+    // Process stdout
+    childProcess.stdout?.on('data', (data: Buffer) => {
+      const output = data.toString()
+
+      // Pass through normal output but look for errors
+      const lines = output.split('\n')
+      for (const line of lines) {
+        if (line.trim()) {
+          consola.log(line)
+          processErrorLine(state, line, recentLines)
+          recentLines.push(line)
+          if (recentLines.length > 5) recentLines.shift()
+        }
+      }
+    })
+
+    // Process stderr with enhanced formatting
+    childProcess.stderr?.on('data', (data: Buffer) => {
+      const output = data.toString()
+
+      const lines = output.split('\n')
+      for (const line of lines) {
+        if (line.trim()) {
+          processErrorLine(state, line, recentLines)
+          recentLines.push(line)
+          if (recentLines.length > 5) recentLines.shift()
+        }
+      }
+    })
+
+    childProcess.on('close', (code: number | null) => {
+      const exitCode = code || 0
+
+      // Print summary if there were errors
+      if (state.errorCount > 0 || state.warningCount > 0) {
+        consola.error('')
+        consola.error(`${colors.bold}📊 Error Summary${colors.reset}`)
+        if (state.errorCount > 0) {
+          consola.error(`${colors.red}❌ Errors: ${state.errorCount}${colors.reset}`)
+        }
+        if (state.warningCount > 0) {
+          consola.error(`${colors.yellow}⚠️ Warnings: ${state.warningCount}${colors.reset}`)
+        }
+        consola.error('')
+
+        if (state.errorCount > 0) {
+          consola.error(`${colors.bold}🔧 Next Steps:${colors.reset}`)
+          consola.error(`${colors.cyan}• Review the errors above and follow the suggestions${colors.reset}`)
+          consola.error(
+            `${colors.cyan}• Run ${colors.bold}pnpm check${colors.reset}${colors.cyan} for comprehensive validation${colors.reset}`,
+          )
+          consola.error(
+            `${colors.cyan}• Run ${colors.bold}pnpm health-check${colors.reset}${colors.cyan} to verify environment setup${colors.reset}`,
+          )
+          consola.error('')
+        }
+      }
+
+      resolve(exitCode)
+    })
+
+    childProcess.on('error', (error: Error) => {
+      consola.error(`${colors.red}${colors.bold}🚨 Process Error:${colors.reset} ${error.message}`)
+      resolve(1)
+    })
+  })
+}
+
+/**
+ * Reset error counters.
+ */
+function resetErrorCounts(state: ErrorReporterState): void {
+  state.errorCount = 0
+  state.warningCount = 0
+}
+
+/**
+ * Get current error and warning counts.
+ */
+function getErrorCounts(state: ErrorReporterState): {errors: number; warnings: number} {
+  return {errors: state.errorCount, warnings: state.warningCount}
+}
+
+/**
+ * Enhanced error reporter interface for compatibility with existing code.
+ * Provides the same interface as the old class but uses functional implementation.
+ */
+interface EnhancedErrorReporter {
+  runWithEnhancedErrors: (command: string, args?: string[], options?: {cwd?: string}) => Promise<number>
+  reset: () => void
+  getCounts: () => {errors: number; warnings: number}
+}
+
+/**
+ * Create an enhanced error reporter instance.
+ * Uses functional implementation while providing class-like interface for compatibility.
+ */
+function createEnhancedErrorReporter(): EnhancedErrorReporter {
+  const state = createErrorReporterState()
+
+  return {
+    runWithEnhancedErrors: (command: string, args: string[] = [], options: {cwd?: string} = {}) =>
+      runWithEnhancedErrors(state, command, args, options),
+    reset: () => resetErrorCounts(state),
+    getCounts: () => getErrorCounts(state),
+  }
+}
+
+/**
+ * CLI interface for enhanced error reporting.
  */
 async function main(): Promise<void> {
   const args = process.argv.slice(2)
 
   if (args.length === 0) {
-    console.error(`${colors.red}Usage: enhanced-error-reporter <command> [args...]${colors.reset}`)
-    console.error(`${colors.yellow}Example: enhanced-error-reporter tsc --noEmit${colors.reset}`)
+    consola.error(`${colors.red}Usage: enhanced-error-reporter <command> [args...]${colors.reset}`)
+    consola.error(`${colors.yellow}Example: enhanced-error-reporter tsc --noEmit${colors.reset}`)
     process.exit(1)
   }
 
-  const reporter = new EnhancedErrorReporter()
+  const reporter = createEnhancedErrorReporter()
   const [command, ...commandArgs] = args
 
-  console.log(
+  consola.log(
     `${colors.blue}${colors.bold}🚀 Running with enhanced error reporting:${colors.reset} ${command} ${commandArgs.join(' ')}`,
   )
-  console.log('')
+  consola.log('')
 
   const exitCode = await reporter.runWithEnhancedErrors(command, commandArgs)
   process.exit(exitCode)
 }
 
-// Export for use as module
-export default EnhancedErrorReporter
+// Export for use as module - maintain backward compatibility
+export default createEnhancedErrorReporter()
 
 // Run as CLI if executed directly (check for import.meta.main in ES modules)
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch(error => {
-    console.error(`${colors.red}${colors.bold}🚨 Fatal Error:${colors.reset} ${error.message}`)
+    consola.error(`${colors.red}${colors.bold}🚨 Fatal Error:${colors.reset} ${error.message}`)
     process.exit(1)
   })
 }

--- a/scripts/health-check.ts
+++ b/scripts/health-check.ts
@@ -8,6 +8,7 @@
 import {execSync} from 'node:child_process'
 import {existsSync, readdirSync} from 'node:fs'
 import process from 'node:process'
+import {consola} from 'consola'
 
 // ANSI color codes for better output formatting
 const colors = {
@@ -19,25 +20,25 @@ const colors = {
   bold: '\u001B[1m',
 } as const
 
-// Helper functions for formatted output
+// Helper functions for formatted output using consola
 function printHeader(message: string): void {
-  console.log(`${colors.blue}${colors.bold}${message}${colors.reset}`)
+  consola.info(`${colors.blue}${colors.bold}${message}${colors.reset}`)
 }
 
 function printSuccess(message: string): void {
-  console.log(`${colors.green}✅ ${message}${colors.reset}`)
+  consola.success(`${colors.green}✅ ${message}${colors.reset}`)
 }
 
 function printWarning(message: string): void {
-  console.log(`${colors.yellow}⚠️  ${message}${colors.reset}`)
+  consola.warn(`${colors.yellow}⚠️  ${message}${colors.reset}`)
 }
 
 function printError(message: string): void {
-  console.log(`${colors.red}❌ ${message}${colors.reset}`)
+  consola.error(`${colors.red}❌ ${message}${colors.reset}`)
 }
 
 function printInfo(message: string): void {
-  console.log(`${colors.blue}ℹ️  ${message}${colors.reset}`)
+  consola.info(`${colors.blue}ℹ️  ${message}${colors.reset}`)
 }
 
 // Utility function to run commands safely
@@ -68,13 +69,13 @@ let healthStatus = 0
 let warningsCount = 0
 
 async function runHealthCheck(): Promise<void> {
-  console.log()
+  consola.log('')
   printHeader('🔍 Running development environment health check...')
-  console.log()
+  consola.log('')
 
   // 1. Check workspace consistency
   printHeader('📦 Validating workspace consistency...')
-  console.log()
+  consola.log('')
 
   const workspaceCheck = runCommand('pnpm check:monorepo', {allowFailure: true})
   if (workspaceCheck.success) {
@@ -83,11 +84,11 @@ async function runHealthCheck(): Promise<void> {
     printError('Workspace consistency check failed')
     healthStatus = 1
   }
-  console.log()
+  consola.log('')
 
   // 2. Validate package dependencies
   printHeader('🔗 Validating package dependencies...')
-  console.log()
+  consola.log('')
 
   const depsCheck = runCommand('pnpm check:dependencies', {allowFailure: true})
   if (depsCheck.success) {
@@ -96,11 +97,11 @@ async function runHealthCheck(): Promise<void> {
     printError('Package dependency validation failed')
     healthStatus = 1
   }
-  console.log()
+  consola.log('')
 
   // 3. Verify TypeScript project references (handle known compatibility issues gracefully)
   printHeader('🔧 Checking TypeScript project references...')
-  console.log()
+  consola.log('')
   printInfo('Running TypeScript build dry run to verify project references...')
 
   // Use a more robust TypeScript check that handles version compatibility issues
@@ -121,11 +122,11 @@ async function runHealthCheck(): Promise<void> {
     printInfo("Run 'tsc --build --dry' for detailed error information")
     healthStatus = 1
   }
-  console.log()
+  consola.log('')
 
   // 4. Test build pipeline integrity
   printHeader('🏗️ Testing build pipeline integrity...')
-  console.log()
+  consola.log('')
   printInfo('Running Turborepo build dry run to verify pipeline...')
 
   const buildDryCheck = runCommand('pnpm run build --dry', {silent: true, allowFailure: true})
@@ -161,11 +162,11 @@ async function runHealthCheck(): Promise<void> {
       printSuccess('All packages have proper build commands')
     }
   }
-  console.log()
+  consola.log('')
 
   // 5. Additional workspace validation checks
   printHeader('🔍 Additional workspace validation...')
-  console.log()
+  consola.log('')
 
   // Check if node_modules exists and is properly structured
   if (existsSync('node_modules')) {
@@ -213,11 +214,11 @@ async function runHealthCheck(): Promise<void> {
     printInfo('Could not check TypeScript build info files')
   }
 
-  console.log()
+  consola.log('')
 
   // 6. Development environment checks
   printHeader('⚙️ Development environment validation...')
-  console.log()
+  consola.log('')
 
   // Check Node.js version
   const nodeVersion = runCommand('node --version', {silent: true})
@@ -235,11 +236,11 @@ async function runHealthCheck(): Promise<void> {
   const turboVersion = runCommand('npx turbo --version', {silent: true})
   printInfo(`Turbo version: ${turboVersion.output.trim()}`)
 
-  console.log()
+  consola.log('')
 
   // 7. Summary and recommendations
   printHeader('📋 Health Check Summary')
-  console.log()
+  consola.log('')
 
   if (healthStatus === 0) {
     if (warningsCount === 0) {
@@ -250,7 +251,7 @@ async function runHealthCheck(): Promise<void> {
     }
   } else {
     printError('Health check failed! Please address the errors above before continuing development.')
-    console.log()
+    consola.log('')
     printInfo('Common fixes:')
     printInfo("  • Run 'pnpm install' to install/update dependencies")
     printInfo("  • Run 'pnpm fix:monorepo' to fix workspace issues")
@@ -258,21 +259,21 @@ async function runHealthCheck(): Promise<void> {
     printInfo("  • Run 'pnpm build' to ensure all packages can build successfully")
   }
 
-  console.log()
+  consola.log('')
   printHeader('🚀 Next steps for development:')
-  console.log()
+  consola.log('')
   printInfo("  • Run 'pnpm dev' to start development servers")
   printInfo("  • Run 'pnpm build:types:watch' for TypeScript watch mode")
   printInfo("  • Run 'pnpm check' for comprehensive quality checks")
   printInfo("  • Run 'pnpm test' to run all tests")
 
-  console.log()
+  consola.log('')
   if (healthStatus === 0) {
     printSuccess('Health check complete! Happy coding! 🎉')
   } else {
     printError('Health check failed! Please fix errors before development.')
   }
-  console.log()
+  consola.log('')
 }
 
 // Run the health check

--- a/scripts/validate-dependencies.ts
+++ b/scripts/validate-dependencies.ts
@@ -4,6 +4,7 @@ import {readdirSync, readFileSync, statSync} from 'node:fs'
 import {dirname, resolve} from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
+import {consola} from 'consola'
 
 const filename = fileURLToPath(import.meta.url)
 const DIRNAME = dirname(filename)
@@ -65,11 +66,11 @@ function getWorkspacePackages(): {name: string; path: string; packageJson: Packa
           packageJson,
         })
       } catch (error) {
-        console.error(`${colors.red}Error reading package.json for ${entry}:${colors.reset}`, error)
+        consola.error(`${colors.red}Error reading package.json for ${entry}:${colors.reset}`, error)
       }
     }
   } catch (error) {
-    console.error(`${colors.red}Error reading packages directory:${colors.reset}`, error)
+    consola.error(`${colors.red}Error reading packages directory:${colors.reset}`, error)
     process.exit(1)
   }
 
@@ -123,12 +124,12 @@ function validatePackageDependencies(pkg: {name: string; packageJson: PackageJso
  * Validate all workspace dependencies
  */
 function validateWorkspaceDependencies(): ValidationError[] {
-  console.log(`${colors.blue}${colors.bold}🔗 Validating workspace dependencies...${colors.reset}`)
+  consola.info(`${colors.blue}${colors.bold}🔗 Validating workspace dependencies...${colors.reset}`)
 
   const packages = getWorkspacePackages()
   const allErrors: ValidationError[] = []
 
-  console.log(`${colors.blue}Found ${packages.length} workspace packages${colors.reset}`)
+  consola.info(`${colors.blue}Found ${packages.length} workspace packages${colors.reset}`)
 
   for (const pkg of packages) {
     const errors = validatePackageDependencies(pkg)
@@ -143,13 +144,13 @@ function validateWorkspaceDependencies(): ValidationError[] {
  */
 function displayValidationResults(errors: ValidationError[]): void {
   if (errors.length === 0) {
-    console.log(`${colors.green}${colors.bold}✅ All workspace dependencies valid${colors.reset}`)
-    console.log(`${colors.green}All internal @sparkle/* dependencies use workspace:* protocol${colors.reset}`)
+    consola.success(`${colors.green}${colors.bold}✅ All workspace dependencies valid${colors.reset}`)
+    consola.success(`${colors.green}All internal @sparkle/* dependencies use workspace:* protocol${colors.reset}`)
     return
   }
 
-  console.log(`${colors.red}${colors.bold}❌ Workspace dependency validation failed${colors.reset}`)
-  console.log(`${colors.red}Found ${errors.length} violation(s):${colors.reset}\n`)
+  consola.error(`${colors.red}${colors.bold}❌ Workspace dependency validation failed${colors.reset}`)
+  consola.error(`${colors.red}Found ${errors.length} violation(s):${colors.reset}\n`)
 
   // Group errors by package for better readability
   const errorsByPackage = new Map<string, ValidationError[]>()
@@ -164,21 +165,21 @@ function displayValidationResults(errors: ValidationError[]): void {
   }
 
   for (const [packageName, packageErrors] of errorsByPackage) {
-    console.log(`${colors.yellow}📦 Package: ${colors.bold}${packageName}${colors.reset}`)
+    consola.log(`${colors.yellow}📦 Package: ${colors.bold}${packageName}${colors.reset}`)
     for (const error of packageErrors) {
-      console.log(
+      consola.log(
         `  ${colors.red}•${colors.reset} ${colors.red}${error.dependencyName}${colors.reset} in ${colors.yellow}${error.dependencyType}${colors.reset}`,
       )
-      console.log(`    Current: ${colors.red}"${error.currentVersion}"${colors.reset}`)
-      console.log(`    Expected: ${colors.green}"workspace:*"${colors.reset}`)
+      consola.log(`    Current: ${colors.red}"${error.currentVersion}"${colors.reset}`)
+      consola.log(`    Expected: ${colors.green}"workspace:*"${colors.reset}`)
     }
-    console.log()
+    consola.log('')
   }
 
-  console.log(`${colors.yellow}${colors.bold}💡 How to fix:${colors.reset}`)
-  console.log(`${colors.yellow}  1. Change internal dependency versions to "workspace:*"${colors.reset}`)
-  console.log(`${colors.yellow}  2. Run "pnpm install" to update lockfile${colors.reset}`)
-  console.log(`${colors.yellow}  3. Or run "pnpm fix:monorepo" to auto-fix with manypkg${colors.reset}`)
+  consola.info(`${colors.yellow}${colors.bold}💡 How to fix:${colors.reset}`)
+  consola.info(`${colors.yellow}  1. Change internal dependency versions to "workspace:*"${colors.reset}`)
+  consola.info(`${colors.yellow}  2. Run "pnpm install" to update lockfile${colors.reset}`)
+  consola.info(`${colors.yellow}  3. Or run "pnpm fix:monorepo" to auto-fix with manypkg${colors.reset}`)
 }
 
 /**
@@ -193,7 +194,7 @@ function main(): void {
       process.exit(1)
     }
   } catch (error) {
-    console.error(`${colors.red}${colors.bold}💥 Validation failed with error:${colors.reset}`, error)
+    consola.error(`${colors.red}${colors.bold}💥 Validation failed with error:${colors.reset}`, error)
     process.exit(1)
   }
 }

--- a/scripts/validate-turbo.ts
+++ b/scripts/validate-turbo.ts
@@ -4,6 +4,7 @@ import {existsSync, readFileSync} from 'node:fs'
 import {dirname, resolve} from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
+import {consola} from 'consola'
 
 const filename = fileURLToPath(import.meta.url)
 const DIRNAME = dirname(filename)
@@ -69,7 +70,7 @@ class TurboValidator {
   private validPackageNames = new Set<string>()
 
   log(message: string, color: ColorKey = 'reset'): void {
-    console.log(`${colors[color]}${message}${colors.reset}`)
+    consola.log(`${colors[color]}${message}${colors.reset}`)
   }
 
   error(message: string): void {


### PR DESCRIPTION
- Update `extract-jsdoc.ts` to use `consola` for logging instead of `console`.
- Refactor `enhanced-error-reporter.ts` to implement functional programming patterns and replaced `console` with `consola`.
- Modify `health-check.ts` to utilize `consola` for all output messages.
- Change `validate-dependencies.ts` to use `consola` for error and validation messages.
- Update `validate-turbo.ts` to replace `console` logging with `consola`.