### PR TITLE
feat: add environment variable management commands and tests

### DIFF
--- a/.ai/plan/feature-moo-dang-shell-1.md
+++ b/.ai/plan/feature-moo-dang-shell-1.md
@@ -69,7 +69,7 @@ This implementation plan outlines the creation of `moo-dang`, a WASM-based web s
 | TASK-014 | Implement shell command parser and dispatcher | ✅ | 2025-09-24 |
 | TASK-015 | Create virtual file system abstraction for shell | ✅ | 2025-09-24 |
 | TASK-016 | Implement basic shell commands (ls, cd, pwd, cat, echo) | ✅ | 2025-09-24 |
-| TASK-017 | Add shell environment variables and path management | |  |
+| TASK-017 | Add shell environment variables and path management | ✅ | 2025-09-24 |
 | TASK-018 | Implement command execution pipeline and I/O redirection | |  |
 
 ### Implementation Phase 4: Zig WASM Integration

--- a/apps/moo-dang/src/shell/parser-env.test.ts
+++ b/apps/moo-dang/src/shell/parser-env.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable no-template-curly-in-string */
+/**
+ * Tests for shell parser environment variable expansion functionality.
+ *
+ * Validates variable substitution, quote handling, and edge cases
+ * in command parsing with environment variable support.
+ */
+
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {expandVariables, parseCommand} from './parser'
+
+describe('Environment Variable Expansion', () => {
+  let testEnvironmentVariables: Record<string, string>
+
+  beforeEach(() => {
+    testEnvironmentVariables = {
+      HOME: '/home/user',
+      PATH: '/bin:/usr/bin:/usr/local/bin',
+      USER: 'testuser',
+      SHELL: '/bin/moo-dang',
+      EMPTY_VAR: '',
+      SPECIAL_CHARS: 'hello world!@#$%',
+    }
+  })
+
+  describe('expandVariables function', () => {
+    it('should expand simple $VAR syntax', () => {
+      expect(expandVariables('$HOME/docs', testEnvironmentVariables)).toBe('/home/user/docs')
+      expect(expandVariables('$USER is here', testEnvironmentVariables)).toBe('testuser is here')
+    })
+
+    it('should expand $\{VAR} syntax', () => {
+      expect(expandVariables('$\{HOME}/documents', testEnvironmentVariables)).toBe('/home/user/documents')
+      expect(expandVariables('User: $\{USER}', testEnvironmentVariables)).toBe('User: testuser')
+    })
+
+    it('should handle multiple variables', () => {
+      expect(expandVariables('$USER lives in $HOME', testEnvironmentVariables)).toBe('testuser lives in /home/user')
+      expect(expandVariables('${USER} uses ${SHELL}', testEnvironmentVariables)).toBe('testuser uses /bin/moo-dang')
+    })
+
+    it('should handle undefined variables', () => {
+      expect(expandVariables('$UNDEFINED_VAR/test', testEnvironmentVariables)).toBe('/test')
+      expect(expandVariables('${UNDEFINED}/test', testEnvironmentVariables)).toBe('/test')
+    })
+
+    it('should handle empty variables', () => {
+      expect(expandVariables('$EMPTY_VAR/test', testEnvironmentVariables)).toBe('/test')
+      expect(expandVariables('prefix-${EMPTY_VAR}-suffix', testEnvironmentVariables)).toBe('prefix--suffix')
+    })
+
+    it('should handle variables with special characters', () => {
+      expect(expandVariables('Value: $SPECIAL_CHARS', testEnvironmentVariables)).toBe('Value: hello world!@#$%')
+    })
+
+    it('should not expand invalid variable names', () => {
+      expect(expandVariables('$123invalid', testEnvironmentVariables)).toBe('$123invalid')
+      expect(expandVariables('${123invalid}', testEnvironmentVariables)).toBe('${123invalid}')
+    })
+
+    it('should handle variables at word boundaries', () => {
+      expect(expandVariables('$HOME_BACKUP', testEnvironmentVariables)).toBe('') // Variable doesn't exist, expands to empty
+      expect(expandVariables('$HOME.backup', testEnvironmentVariables)).toBe('/home/user.backup')
+      expect(expandVariables('$HOME/', testEnvironmentVariables)).toBe('/home/user/')
+    })
+
+    it('should handle consecutive variables', () => {
+      expect(expandVariables('$USER$SHELL', testEnvironmentVariables)).toBe('testuser/bin/moo-dang')
+      expect(expandVariables('${USER}${SHELL}', testEnvironmentVariables)).toBe('testuser/bin/moo-dang')
+    })
+  })
+
+  describe('parseCommand with environment variables', () => {
+    it('should expand variables in unquoted arguments', () => {
+      expect(parseCommand('ls $HOME', testEnvironmentVariables)).toEqual(['ls', '/home/user'])
+      expect(parseCommand('cd $HOME/docs', testEnvironmentVariables)).toEqual(['cd', '/home/user/docs'])
+    })
+
+    it('should expand variables in double-quoted strings', () => {
+      expect(parseCommand('echo "Welcome $USER"', testEnvironmentVariables)).toEqual(['echo', 'Welcome testuser'])
+      expect(parseCommand('cat "$HOME/file.txt"', testEnvironmentVariables)).toEqual(['cat', '/home/user/file.txt'])
+    })
+
+    it('should not expand variables in single-quoted strings', () => {
+      expect(parseCommand("echo '$HOME is not expanded'", testEnvironmentVariables)).toEqual([
+        'echo',
+        '$HOME is not expanded',
+      ])
+      expect(parseCommand("ls '$USER/docs'", testEnvironmentVariables)).toEqual(['ls', '$USER/docs'])
+    })
+
+    it('should handle mixed quoting styles', () => {
+      expect(parseCommand('echo "Hello $USER" and \'$HOME not expanded\'', testEnvironmentVariables)).toEqual([
+        'echo',
+        'Hello testuser',
+        'and',
+        '$HOME not expanded',
+      ])
+    })
+
+    it('should handle complex variable patterns', () => {
+      expect(parseCommand('echo ${HOME}/docs $USER.txt', testEnvironmentVariables)).toEqual([
+        'echo',
+        '/home/user/docs',
+        'testuser.txt',
+      ])
+    })
+
+    it('should handle variables in command names', () => {
+      // Note: This is unusual but theoretically possible
+      testEnvironmentVariables.CMD = 'echo'
+      expect(parseCommand('$CMD hello', testEnvironmentVariables)).toEqual(['echo', 'hello'])
+    })
+
+    it('should handle environment assignment syntax', () => {
+      expect(parseCommand('PATH=$PATH:/new/bin some_command', testEnvironmentVariables)).toEqual([
+        'PATH=/bin:/usr/bin:/usr/local/bin:/new/bin',
+        'some_command',
+      ])
+    })
+
+    it('should preserve original behavior without environment variables', () => {
+      expect(parseCommand('echo $HOME')).toEqual(['echo', '$HOME'])
+      expect(parseCommand('ls "${USER}"')).toEqual(['ls', '${USER}'])
+    })
+
+    it('should handle empty environment variables', () => {
+      const emptyEnv: Record<string, string> = {}
+      expect(parseCommand('echo $UNDEFINED', emptyEnv)).toEqual(['echo', ''])
+      expect(parseCommand('echo "${UNDEFINED}"', emptyEnv)).toEqual(['echo', ''])
+    })
+
+    it('should handle special shell characters in variable values', () => {
+      const specialEnv = {
+        SPACES: 'hello world',
+        QUOTES: 'say "hello"',
+        BACKSLASH: String.raw`path\to\file`,
+      }
+
+      expect(parseCommand('echo $SPACES', specialEnv)).toEqual(['echo', 'hello world'])
+      expect(parseCommand('echo "$QUOTES"', specialEnv)).toEqual(['echo', 'say "hello"'])
+      expect(parseCommand('echo $BACKSLASH', specialEnv)).toEqual(['echo', String.raw`path\to\file`])
+    })
+  })
+
+  describe('Edge cases and error handling', () => {
+    it('should handle malformed variable syntax', () => {
+      expect(expandVariables('$', testEnvironmentVariables)).toBe('$')
+      expect(expandVariables('${', testEnvironmentVariables)).toBe('${')
+      expect(expandVariables('${}', testEnvironmentVariables)).toBe('${}')
+    })
+
+    it('should handle nested braces (simplified behavior)', () => {
+      // Note: Real shells don't support nested ${} syntax, and our implementation
+      // expands variables from inside-out, which is acceptable behavior
+      expect(expandVariables('${HOME${USER}}', testEnvironmentVariables)).toBe('${HOMEtestuser}')
+    })
+
+    it('should handle long variable names', () => {
+      const longVar = 'A'.repeat(100)
+      const longEnv = {[longVar]: 'long_value'}
+      expect(expandVariables(`$${longVar}`, longEnv)).toBe('long_value')
+    })
+
+    it('should handle unicode in variable values', () => {
+      const unicodeEnv = {UNICODE: '🚀 Hello 世界'}
+      expect(expandVariables('$UNICODE', unicodeEnv)).toBe('🚀 Hello 世界')
+    })
+  })
+
+  describe('Performance and security considerations', () => {
+    it('should handle many variables efficiently', () => {
+      const manyVars: Record<string, string> = {}
+      for (let i = 0; i < 100; i++) {
+        manyVars[`VAR_${i}`] = `value_${i}`
+      }
+
+      const text = Object.keys(manyVars)
+        .map(key => `$${key}`)
+        .join(' ')
+
+      const result = expandVariables(text, manyVars)
+      expect(result).toContain('value_0')
+      expect(result).toContain('value_99')
+    })
+
+    it('should handle large variable values', () => {
+      const largeValue = 'x'.repeat(10000)
+      const largeEnv = {LARGE_VAR: largeValue}
+      expect(expandVariables('prefix $LARGE_VAR suffix', largeEnv)).toBe(`prefix ${largeValue} suffix`)
+    })
+
+    it('should not be vulnerable to injection attacks', () => {
+      const maliciousEnv = {
+        MALICIOUS: '"; rm -rf / #',
+      }
+      expect(expandVariables('echo $MALICIOUS', maliciousEnv)).toBe('echo "; rm -rf / #')
+    })
+  })
+})

--- a/apps/moo-dang/src/shell/parser.ts
+++ b/apps/moo-dang/src/shell/parser.ts
@@ -1,35 +1,63 @@
 /**
  * Shell command parser for processing user input into executable commands.
  *
- * Provides robust parsing capabilities with support for quotes, special characters,
- * and various shell constructs while maintaining security in the browser environment.
+ * This parser provides secure shell-like behavior in browser environments by implementing
+ * familiar Unix shell quoting conventions while preventing security vulnerabilities.
+ * The design balances user expectations from terminal environments with browser safety requirements.
  */
 
 /**
- * Expands environment variables in a string.
+ * Quote handling strategy for parsed command tokens.
  *
- * Supports both $VAR and ${VAR} syntax for variable substitution.
- * Variables are expanded using the provided environment variable mapping.
+ * Tracks how each token was quoted in the original command to determine variable expansion behavior.
+ * This distinction is critical because shell conventions require different expansion rules
+ * for single-quoted, double-quoted, and unquoted text.
+ */
+type QuoteType = 'none' | 'single' | 'double'
+
+/**
+ * Internal representation of a parsed command token with its quoting context.
+ *
+ * Separating content from quote type allows the parser to apply shell-compliant
+ * variable expansion rules after tokenization is complete.
+ */
+interface ParsedToken {
+  readonly content: string
+  readonly quoteType: QuoteType
+}
+
+/**
+ * Expands environment variables in text using shell-standard variable substitution.
+ *
+ * Implements both $VAR and ${VAR} syntax because many shell users expect both forms
+ * to work interchangeably. The ${VAR} form is processed first to handle edge cases
+ * where variable names might be ambiguous (e.g., "$VARname" vs "${VAR}name").
+ *
+ * Variables that don't exist expand to empty strings, following POSIX shell behavior
+ * rather than throwing errors, which maintains script compatibility.
  *
  * @param text - Text containing variable references to expand
  * @param environmentVariables - Map of environment variable names to values
- * @returns Text with variables expanded to their values
+ * @returns Text with variables expanded to their values or empty strings for undefined variables
  *
  * @example
  * ```typescript
  * expandVariables('$HOME/docs', {HOME: '/home/user'}) // Returns: '/home/user/docs'
  * expandVariables('${PATH}:/bin', {PATH: '/usr/bin'}) // Returns: '/usr/bin:/bin'
+ * expandVariables('$UNDEFINED', {}) // Returns: '' (empty string, not error)
  * ```
  */
 export function expandVariables(text: string, environmentVariables: Record<string, string>): string {
   let result = text
 
-  // Handle ${VAR} syntax first (more specific)
+  // Process ${VAR} syntax first because it's more specific and prevents ambiguity
+  // when variable names are followed by word characters (e.g., "${VAR}name" vs "$VARname")
   result = result.replaceAll(/\$\{([a-z_]\w*)\}/gi, (_match, varName) => {
     return environmentVariables[varName] || ''
   })
 
-  // Handle $VAR syntax (must be followed by non-word character or end of string)
+  // Process $VAR syntax only when followed by non-word characters or end of string
+  // This prevents incorrect expansion of "$VARname" when only "VAR" is defined
   result = result.replaceAll(/\$([a-z_]\w*)(?=\W|$)/gi, (_match, varName) => {
     return environmentVariables[varName] || ''
   })
@@ -38,12 +66,17 @@ export function expandVariables(text: string, environmentVariables: Record<strin
 }
 
 /**
- * Parse command string into command and arguments with quote handling and variable expansion.
+ * Parse command string into command and arguments with shell-compliant quote handling and variable expansion.
  *
- * Supports basic shell quoting with single and double quotes to handle arguments
- * containing spaces or special characters. Variables are expanded in double-quoted
- * strings and unquoted text, but not in single-quoted strings (following shell conventions).
- * The parser is designed to be safe for browser execution while providing familiar shell-like behavior.
+ * Implements Unix shell quoting conventions because users expect familiar terminal behavior.
+ * Single quotes preserve literal text (no variable expansion) to allow passing literal $
+ * characters. Double quotes allow variable expansion while preserving spaces, enabling
+ * complex argument construction. This two-phase approach (tokenize, then expand) prevents
+ * security issues while maintaining shell compatibility.
+ *
+ * The parser maintains quote type information to apply correct expansion rules after
+ * tokenization, ensuring that 'echo $HOME' and "echo $HOME" behave as users expect
+ * from traditional shells.
  *
  * @param command - Raw command string to parse
  * @param environmentVariables - Optional environment variables for expansion
@@ -55,64 +88,60 @@ export function expandVariables(text: string, environmentVariables: Record<strin
  * parseCommand("cat 'file with spaces.txt'") // Returns: ['cat', 'file with spaces.txt']
  * parseCommand('ls -la $HOME', {HOME: '/home/user'}) // Returns: ['ls', '-la', '/home/user']
  * parseCommand('echo "$HOME and $PATH"', {HOME: '/home/user', PATH: '/bin'}) // Returns: ['echo', '/home/user and /bin']
+ * parseCommand("echo '$HOME'") // Returns: ['echo', '$HOME'] (literal, no expansion)
  * ```
  */
 export function parseCommand(command: string, environmentVariables?: Record<string, string>): string[] {
-  interface ParsedPart {
-    content: string
-    quoteType: 'none' | 'single' | 'double'
-  }
-
-  const parts: ParsedPart[] = []
-  let current = ''
+  const tokens: ParsedToken[] = []
+  let currentTokenContent = ''
   let inQuotes = false
   let quoteChar = ''
-  let currentQuoteType: 'none' | 'single' | 'double' = 'none'
+  let currentQuoteType: QuoteType = 'none'
 
-  const chars = Array.from(command)
+  const characters = Array.from(command)
 
-  for (const char of chars) {
+  for (const char of characters) {
     if ((char === '"' || char === "'") && !inQuotes) {
-      // Start of quoted section - don't include the quote character
+      // Start of quoted section - quote character is consumed but not included in content
       inQuotes = true
       quoteChar = char
       currentQuoteType = char === '"' ? 'double' : 'single'
     } else if (char === quoteChar && inQuotes) {
-      // End of quoted section - don't include the quote character
-      // Keep currentQuoteType to remember this token was quoted
+      // End of quoted section - quote character is consumed but not included in content
+      // Preserve currentQuoteType to track that this token was quoted
       inQuotes = false
       quoteChar = ''
     } else if (char === ' ' && !inQuotes) {
-      // Space outside quotes - end current token
-      if (current || currentQuoteType !== 'none') {
-        parts.push({content: current, quoteType: currentQuoteType})
-        current = ''
+      // Unquoted space acts as token separator
+      if (currentTokenContent || currentQuoteType !== 'none') {
+        tokens.push({content: currentTokenContent, quoteType: currentQuoteType})
+        currentTokenContent = ''
         currentQuoteType = 'none'
       }
     } else {
-      // Regular character - add to current token
-      current += char
+      // Regular character becomes part of current token
+      currentTokenContent += char
     }
   }
 
-  // Add final token if any
-  if (current || currentQuoteType !== 'none') {
-    parts.push({content: current, quoteType: currentQuoteType})
+  // Add final token if any content or if it was an empty quoted string
+  if (currentTokenContent || currentQuoteType !== 'none') {
+    tokens.push({content: currentTokenContent, quoteType: currentQuoteType})
   }
 
-  // Process parts based on quoting and environment variables
+  // Apply variable expansion based on quote type and return final command parts
   if (environmentVariables) {
-    return parts.map(part => {
-      if (part.quoteType === 'single') {
-        // Single quotes: no variable expansion
-        return part.content
+    return tokens.map((token: ParsedToken) => {
+      if (token.quoteType === 'single') {
+        // Single quotes preserve literal content - no variable expansion
+        return token.content
       } else {
-        // Double quotes or unquoted: expand variables
-        return expandVariables(part.content, environmentVariables)
+        // Double quotes and unquoted text allow variable expansion
+        return expandVariables(token.content, environmentVariables)
       }
-    }) // Don't filter empty strings when environment variables are provided
+    }) // Preserve empty strings when environment variables are provided
   }
 
-  // No environment variables provided - just return content and filter empty strings
-  return parts.map(part => part.content).filter(content => content !== '')
+  // No environment variables - return content and filter empty strings for backward compatibility
+  return tokens.map((token: ParsedToken) => token.content).filter((content: string) => content !== '')
 }

--- a/apps/moo-dang/src/shell/parser.ts
+++ b/apps/moo-dang/src/shell/parser.ts
@@ -6,50 +6,113 @@
  */
 
 /**
- * Parse command string into command and arguments with quote handling.
+ * Expands environment variables in a string.
+ *
+ * Supports both $VAR and ${VAR} syntax for variable substitution.
+ * Variables are expanded using the provided environment variable mapping.
+ *
+ * @param text - Text containing variable references to expand
+ * @param environmentVariables - Map of environment variable names to values
+ * @returns Text with variables expanded to their values
+ *
+ * @example
+ * ```typescript
+ * expandVariables('$HOME/docs', {HOME: '/home/user'}) // Returns: '/home/user/docs'
+ * expandVariables('${PATH}:/bin', {PATH: '/usr/bin'}) // Returns: '/usr/bin:/bin'
+ * ```
+ */
+export function expandVariables(text: string, environmentVariables: Record<string, string>): string {
+  let result = text
+
+  // Handle ${VAR} syntax first (more specific)
+  result = result.replaceAll(/\$\{([a-z_]\w*)\}/gi, (_match, varName) => {
+    return environmentVariables[varName] || ''
+  })
+
+  // Handle $VAR syntax (must be followed by non-word character or end of string)
+  result = result.replaceAll(/\$([a-z_]\w*)(?=\W|$)/gi, (_match, varName) => {
+    return environmentVariables[varName] || ''
+  })
+
+  return result
+}
+
+/**
+ * Parse command string into command and arguments with quote handling and variable expansion.
  *
  * Supports basic shell quoting with single and double quotes to handle arguments
- * containing spaces or special characters. The parser is designed to be safe
- * for browser execution while providing familiar shell-like behavior.
+ * containing spaces or special characters. Variables are expanded in double-quoted
+ * strings and unquoted text, but not in single-quoted strings (following shell conventions).
+ * The parser is designed to be safe for browser execution while providing familiar shell-like behavior.
  *
  * @param command - Raw command string to parse
+ * @param environmentVariables - Optional environment variables for expansion
  * @returns Array of parsed command parts, with the first element being the command name
  *
  * @example
  * ```typescript
  * parseCommand('echo "hello world"') // Returns: ['echo', 'hello world']
  * parseCommand("cat 'file with spaces.txt'") // Returns: ['cat', 'file with spaces.txt']
- * parseCommand('ls -la /home') // Returns: ['ls', '-la', '/home']
+ * parseCommand('ls -la $HOME', {HOME: '/home/user'}) // Returns: ['ls', '-la', '/home/user']
+ * parseCommand('echo "$HOME and $PATH"', {HOME: '/home/user', PATH: '/bin'}) // Returns: ['echo', '/home/user and /bin']
  * ```
  */
-export function parseCommand(command: string): string[] {
-  const parts: string[] = []
+export function parseCommand(command: string, environmentVariables?: Record<string, string>): string[] {
+  interface ParsedPart {
+    content: string
+    quoteType: 'none' | 'single' | 'double'
+  }
+
+  const parts: ParsedPart[] = []
   let current = ''
   let inQuotes = false
   let quoteChar = ''
+  let currentQuoteType: 'none' | 'single' | 'double' = 'none'
 
   const chars = Array.from(command)
 
   for (const char of chars) {
     if ((char === '"' || char === "'") && !inQuotes) {
+      // Start of quoted section - don't include the quote character
       inQuotes = true
       quoteChar = char
+      currentQuoteType = char === '"' ? 'double' : 'single'
     } else if (char === quoteChar && inQuotes) {
+      // End of quoted section - don't include the quote character
+      // Keep currentQuoteType to remember this token was quoted
       inQuotes = false
       quoteChar = ''
     } else if (char === ' ' && !inQuotes) {
-      if (current) {
-        parts.push(current)
+      // Space outside quotes - end current token
+      if (current || currentQuoteType !== 'none') {
+        parts.push({content: current, quoteType: currentQuoteType})
         current = ''
+        currentQuoteType = 'none'
       }
     } else {
+      // Regular character - add to current token
       current += char
     }
   }
 
-  if (current) {
-    parts.push(current)
+  // Add final token if any
+  if (current || currentQuoteType !== 'none') {
+    parts.push({content: current, quoteType: currentQuoteType})
   }
 
-  return parts
+  // Process parts based on quoting and environment variables
+  if (environmentVariables) {
+    return parts.map(part => {
+      if (part.quoteType === 'single') {
+        // Single quotes: no variable expansion
+        return part.content
+      } else {
+        // Double quotes or unquoted: expand variables
+        return expandVariables(part.content, environmentVariables)
+      }
+    }) // Don't filter empty strings when environment variables are provided
+  }
+
+  // No environment variables provided - just return content and filter empty strings
+  return parts.map(part => part.content).filter(content => content !== '')
 }


### PR DESCRIPTION
- Implement `env`, `export`, `printenv`, and `unset` commands for managing environment variables.
- Enhance command parsing to support variable expansion in commands.
- Add tests for environment variable expansion and command execution.
- Update shell worker to resolve commands using PATH if not found in built-ins.

Relates to TASK-017 on #943.